### PR TITLE
change Cache-Control to contain fields of directives

### DIFF
--- a/headers-core/src/encode.rs
+++ b/headers-core/src/encode.rs
@@ -1,13 +1,13 @@
 use std::fmt;
 
 /// Format an array into a comma-delimited string.
-pub fn comma_delimited<'a, T: fmt::Display + 'a>(f: &mut fmt::Formatter, mut iter: impl Iterator<Item=&'a T>) -> fmt::Result {
+pub fn comma_delimited<T: fmt::Display>(f: &mut fmt::Formatter, mut iter: impl Iterator<Item=T>) -> fmt::Result {
     if let Some(part) = iter.next() {
-        fmt::Display::fmt(part, f)?;
+        fmt::Display::fmt(&part, f)?;
     }
     for part in iter {
         f.write_str(", ")?;
-        fmt::Display::fmt(part, f)?;
+        fmt::Display::fmt(&part, f)?;
     }
     Ok(())
 }

--- a/headers-ext/Cargo.toml
+++ b/headers-ext/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 
 [dependencies]
 base64 = "0.9"
+bitflags = "1.0"
 bytes = "0.4"
 headers-core = { path = "../headers-core" }
 headers-derive = { path = "../headers-derive" }

--- a/headers-ext/src/common/cache_control.rs
+++ b/headers-ext/src/common/cache_control.rs
@@ -1,5 +1,9 @@
 use std::fmt;
+use std::iter::FromIterator;
 use std::str::FromStr;
+use std::time::Duration;
+
+use util::Seconds;
 
 /// `Cache-Control` header, defined in [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2)
 ///
@@ -25,120 +29,301 @@ use std::str::FromStr;
 ///
 /// ```
 /// # extern crate headers_ext as headers;
-/// use headers::{CacheControl, CacheDirective};
+/// use headers::CacheControl;
 ///
-/// let cc = CacheControl::new(vec![CacheDirective::NO_CACHE]);
+/// let cc = CacheControl::new();
 /// ```
-#[derive(PartialEq, Clone, Debug, Header)]
-#[header(csv)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct CacheControl {
-    directives: Vec<CacheDirective>,
+    flags: Flags,
+    max_age: Option<Seconds>,
+    max_stale: Option<Seconds>,
+    min_fresh: Option<Seconds>,
+    s_max_age: Option<Seconds>,
+}
+
+bitflags! {
+    struct Flags: u32 {
+        const NO_CACHE         = 0b00000001;
+        const NO_STORE         = 0b00000010;
+        const NO_TRANSFORM     = 0b00000100;
+        const ONLY_IF_CACHED   = 0b00001000;
+        const MUST_REVALIDATE  = 0b00010000;
+        const PUBLIC           = 0b00100000;
+        const PRIVATE          = 0b01000000;
+        const PROXY_REVALIDATE = 0b10000000;
+    }
 }
 
 impl CacheControl {
-    pub fn new<I>(iter: I) -> Self
-    where
-        I: IntoIterator<Item=CacheDirective>,
-    {
-        let directives = iter
-            .into_iter()
-            .collect();
-
+    /// Construct a new empty `CacheControl` header.
+    pub fn new() -> Self {
         CacheControl {
-            directives,
+            flags: Flags::empty(),
+            max_age: None,
+            max_stale: None,
+            min_fresh: None,
+            s_max_age: None,
         }
+    }
+
+    // getters
+
+    /// Check if the `no-cache` directive is set.
+    pub fn no_cache(&self) -> bool {
+        self.flags.contains(Flags::NO_CACHE)
+    }
+
+    /// Check if the `no-store` directive is set.
+    pub fn no_store(&self) -> bool {
+        self.flags.contains(Flags::NO_STORE)
+    }
+
+    /// Check if the `no-transform` directive is set.
+    pub fn no_transform(&self) -> bool {
+        self.flags.contains(Flags::NO_TRANSFORM)
+    }
+
+    /// Check if the `only-if-cached` directive is set.
+    pub fn only_if_cached(&self) -> bool {
+        self.flags.contains(Flags::ONLY_IF_CACHED)
+    }
+
+    /// Check if the `public` directive is set.
+    pub fn public(&self) -> bool {
+        self.flags.contains(Flags::PUBLIC)
+    }
+
+    /// Check if the `private` directive is set.
+    pub fn private(&self) -> bool {
+        self.flags.contains(Flags::PRIVATE)
+    }
+
+    /// Get the value of the `max-age` directive if set.
+    pub fn max_age(&self) -> Option<Duration> {
+        self.max_age.map(Into::into)
+    }
+
+    /// Get the value of the `max-stale` directive if set.
+    pub fn max_stale(&self) -> Option<Duration> {
+        self.max_stale.map(Into::into)
+    }
+
+
+    /// Get the value of the `min-fresh` directive if set.
+    pub fn min_fresh(&self) -> Option<Duration> {
+        self.min_fresh.map(Into::into)
+    }
+
+    /// Get the value of the `s-maxage` directive if set.
+    pub fn s_max_age(&self) -> Option<Duration> {
+        self.s_max_age.map(Into::into)
+    }
+
+    // setters
+
+    /// Set the `no-cache` directive.
+    pub fn with_no_cache(mut self) -> Self {
+        self.flags.insert(Flags::NO_CACHE);
+        self
+    }
+
+    /// Set the `no-store` directive.
+    pub fn with_no_store(mut self) -> Self {
+        self.flags.insert(Flags::NO_STORE);
+        self
+    }
+
+    /// Set the `no-transform` directive.
+    pub fn with_no_transform(mut self) -> Self {
+        self.flags.insert(Flags::NO_TRANSFORM);
+        self
+    }
+
+    /// Set the `only-if-cached` directive.
+    pub fn with_only_if_cached(mut self) -> Self {
+        self.flags.insert(Flags::ONLY_IF_CACHED);
+        self
+    }
+
+    /// Set the `private` directive.
+    pub fn with_private(mut self) -> Self {
+        self.flags.insert(Flags::PRIVATE);
+        self
+    }
+
+    /// Set the `public` directive.
+    pub fn with_public(mut self) -> Self {
+        self.flags.insert(Flags::PUBLIC);
+        self
+    }
+
+    /// Set the `max-age` directive.
+    pub fn with_max_age(mut self, seconds: Duration) -> Self {
+        self.max_age = Some(seconds.into());
+        self
+    }
+
+    /// Set the `max-stale` directive.
+    pub fn with_max_stale(mut self, seconds: Duration) -> Self {
+        self.max_stale = Some(seconds.into());
+        self
+    }
+
+    /// Set the `min-fresh` directive.
+    pub fn with_min_fresh(mut self, seconds: Duration) -> Self {
+        self.min_fresh = Some(seconds.into());
+        self
+    }
+
+    /// Set the `s-maxage` directive.
+    pub fn with_s_max_age(mut self, seconds: Duration) -> Self {
+        self.s_max_age = Some(seconds.into());
+        self
     }
 }
 
-/// `CacheControl` contains a list of these directives.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct CacheDirective(Directive);
+impl ::Header for CacheControl {
+    const NAME: &'static ::HeaderName = &::http::header::CACHE_CONTROL;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    fn decode(values: &mut ::Values) -> Option<Self> {
+        ::headers_core::decode::from_comma_delimited(values)
+            .map(|FromIter(cc)| cc)
+
+    }
+
+    fn encode(&self, values: &mut ::ToValues) {
+        values.append_fmt(&Fmt(self));
+    }
+}
+
+// Adapter to be used in Header::decode
+struct FromIter(CacheControl);
+
+impl FromIterator<KnownDirective> for FromIter {
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item=KnownDirective>,
+    {
+        let mut cc = CacheControl::new();
+
+        // ignore all unknown directives
+        let iter = iter
+            .into_iter()
+            .filter_map(|dir| match dir {
+                KnownDirective::Known(dir) => Some(dir),
+                KnownDirective::Unknown => None,
+            });
+
+        for directive in iter {
+            match directive {
+                Directive::NoCache => {
+                    cc.flags.insert(Flags::NO_CACHE);
+                },
+                Directive::NoStore => {
+                    cc.flags.insert(Flags::NO_STORE);
+                },
+                Directive::NoTransform => {
+                    cc.flags.insert(Flags::NO_TRANSFORM);
+                },
+                Directive::OnlyIfCached => {
+                    cc.flags.insert(Flags::ONLY_IF_CACHED);
+                },
+                Directive::MustRevalidate => {
+                    cc.flags.insert(Flags::MUST_REVALIDATE);
+                },
+                Directive::Public => {
+                    cc.flags.insert(Flags::PUBLIC);
+                },
+                Directive::Private => {
+                    cc.flags.insert(Flags::PRIVATE);
+                },
+                Directive::ProxyRevalidate => {
+                    cc.flags.insert(Flags::PROXY_REVALIDATE);
+                },
+                Directive::MaxAge(secs) => {
+                    cc.max_age = Some(Duration::from_secs(secs.into()).into());
+                },
+                Directive::MaxStale(secs) => {
+                    cc.max_stale = Some(Duration::from_secs(secs.into()).into());
+                },
+                Directive::MinFresh(secs) => {
+                    cc.min_fresh = Some(Duration::from_secs(secs.into()).into());
+                },
+                Directive::SMaxAge(secs) => {
+                    cc.s_max_age = Some(Duration::from_secs(secs.into()).into());
+                },
+            }
+        }
+
+        FromIter(cc)
+    }
+}
+
+struct Fmt<'a>(&'a CacheControl);
+
+impl<'a> fmt::Display for Fmt<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let if_flag = |f: Flags, dir: Directive| {
+            if self.0.flags.contains(f) {
+                Some(dir)
+            } else {
+                None
+            }
+        };
+
+        let slice = &[
+            if_flag(Flags::NO_CACHE, Directive::NoCache),
+            if_flag(Flags::NO_STORE, Directive::NoStore),
+            if_flag(Flags::NO_TRANSFORM, Directive::NoTransform),
+            if_flag(Flags::ONLY_IF_CACHED, Directive::OnlyIfCached),
+            if_flag(Flags::MUST_REVALIDATE, Directive::MustRevalidate),
+            if_flag(Flags::PUBLIC, Directive::Public),
+            if_flag(Flags::PRIVATE, Directive::Private),
+            if_flag(Flags::PROXY_REVALIDATE, Directive::ProxyRevalidate),
+            self.0.max_age.as_ref().map(|s| Directive::MaxAge(s.as_u64())),
+            self.0.max_stale.as_ref().map(|s| Directive::MaxStale(s.as_u64())),
+            self.0.min_fresh.as_ref().map(|s| Directive::MinFresh(s.as_u64())),
+            self.0.s_max_age.as_ref().map(|s| Directive::SMaxAge(s.as_u64())),
+        ];
+
+        let iter = slice
+            .iter()
+            .filter_map(|o| *o);
+
+        ::headers_core::encode::comma_delimited(f, iter)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum KnownDirective {
+    Known(Directive),
+    Unknown,
+}
+
+#[derive(Clone, Copy)]
 enum Directive {
-    /// "no-cache"
     NoCache,
-    /// "no-store"
     NoStore,
-    /// "no-transform"
     NoTransform,
-    /// "only-if-cached"
     OnlyIfCached,
 
     // request directives
-    /// "max-age=delta"
-    MaxAge(u32),
-    /// "max-stale=delta"
-    MaxStale(u32),
-    /// "min-fresh=delta"
-    MinFresh(u32),
+    MaxAge(u64),
+    MaxStale(u64),
+    MinFresh(u64),
 
     // response directives
-    /// "must-revalidate"
     MustRevalidate,
-    /// "public"
     Public,
-    /// "private"
     Private,
-    /// "proxy-revalidate"
     ProxyRevalidate,
-    /// "s-maxage=delta"
-    SMaxAge(u32),
-
-    /// Extension directives. Optionally include an argument.
-    Extension(String, Option<String>)
+    SMaxAge(u64),
 }
 
-impl CacheDirective {
-    /// "no-cache"
-    pub const NO_CACHE: Self = CacheDirective(Directive::NoCache);
-
-    /// "no-store"
-    pub const NO_STORE: Self = CacheDirective(Directive::NoStore);
-
-    /// "no-transform"
-    pub const NO_TRANSFORM: Self = CacheDirective(Directive::NoTransform);
-
-    /// "only-if-cached"
-    pub const ONLY_IF_CACHED: Self = CacheDirective(Directive::OnlyIfCached);
-
-    /// "must-revalidate"
-    pub const MUST_REVALIDATE: Self = CacheDirective(Directive::MustRevalidate);
-
-    /// "public"
-    pub const PUBLIC: Self = CacheDirective(Directive::Public);
-
-    /// "private"
-    pub const PRIVATE: Self = CacheDirective(Directive::Private);
-
-    /// "proxy-revalidate"
-    pub const PROXY_REVALIDATE: Self = CacheDirective(Directive::ProxyRevalidate);
-
-    //TODO: accept Duration instead?
-    /// "max-age=delta"
-    pub fn max_age(age: u32) -> Self {
-        CacheDirective(Directive::MaxAge(age))
-    }
-
-    /// "max-stale=delta"
-    pub fn max_stale(age: u32) -> Self {
-        CacheDirective(Directive::MaxStale(age))
-    }
-
-    /// "min-fresh=delta"
-    pub fn min_fresh(age: u32) -> Self {
-        CacheDirective(Directive::MinFresh(age))
-    }
-
-    /// "s-maxage=delta"
-    pub fn s_max_age(age: u32) -> Self {
-        CacheDirective(Directive::SMaxAge(age))
-    }
-}
-
-impl fmt::Display for CacheDirective {
+impl fmt::Display for Directive {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(match self.0 {
+        fmt::Display::fmt(match *self {
             Directive::NoCache => "no-cache",
             Directive::NoStore => "no-store",
             Directive::NoTransform => "no-transform",
@@ -153,22 +338,14 @@ impl fmt::Display for CacheDirective {
             Directive::Private => "private",
             Directive::ProxyRevalidate => "proxy-revalidate",
             Directive::SMaxAge(secs) => return write!(f, "s-maxage={}", secs),
-
-            Directive::Extension(ref name, None) => &name[..],
-            Directive::Extension(ref name, Some(ref arg)) => return write!(f, "{}={}", name, arg),
-
         }, f)
     }
 }
 
-/// Error if `CacheDirective` fails to parse.
-#[derive(Debug)]
-pub struct FromStrErr(());
-
-impl FromStr for CacheDirective {
-    type Err = FromStrErr;
-    fn from_str(s: &str) -> Result<CacheDirective, Self::Err> {
-        let directive = match s {
+impl FromStr for KnownDirective {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(KnownDirective::Known(match s {
             "no-cache" => Directive::NoCache,
             "no-store" => Directive::NoStore,
             "no-transform" => Directive::NoTransform,
@@ -177,36 +354,33 @@ impl FromStr for CacheDirective {
             "public" => Directive::Public,
             "private" => Directive::Private,
             "proxy-revalidate" => Directive::ProxyRevalidate,
-            "" => return Err(FromStrErr(())),
+            "" => return Err(()),
             _ => match s.find('=') {
                 Some(idx) if idx+1 < s.len() => match (&s[..idx], (&s[idx+1..]).trim_matches('"')) {
-                    ("max-age" , secs) => secs.parse().map(Directive::MaxAge).map_err(|_| FromStrErr(()))?,
-                    ("max-stale", secs) => secs.parse().map(Directive::MaxStale).map_err(|_| FromStrErr(()))?,
-                    ("min-fresh", secs) => secs.parse().map(Directive::MinFresh).map_err(|_| FromStrErr(()))?,
-                    ("s-maxage", secs) => secs.parse().map(Directive::SMaxAge).map_err(|_| FromStrErr(()))?,
-                    (left, right) => Directive::Extension(left.to_owned(), Some(right.to_owned()))
+                    ("max-age" , secs) => secs.parse().map(Directive::MaxAge).map_err(|_| ())?,
+                    ("max-stale", secs) => secs.parse().map(Directive::MaxStale).map_err(|_| ())?,
+                    ("min-fresh", secs) => secs.parse().map(Directive::MinFresh).map_err(|_| ())?,
+                    ("s-maxage", secs) => secs.parse().map(Directive::SMaxAge).map_err(|_| ())?,
+                    _unknown => return Ok(KnownDirective::Unknown),
                 },
-                Some(_) => return Err(FromStrErr(())),
-                None => Directive::Extension(s.to_owned(), None),
+                Some(_) | None => return Ok(KnownDirective::Unknown),
             }
-        };
-        Ok(CacheDirective(directive))
+        }))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use super::super::test_decode;
+    use super::super::{test_decode, test_encode};
 
     #[test]
     fn test_parse_multiple_headers() {
         assert_eq!(
             test_decode::<CacheControl>(&["no-cache", "private"]).unwrap(),
-            CacheControl::new(vec![
-                CacheDirective::NO_CACHE,
-                CacheDirective::PRIVATE,
-            ]),
+            CacheControl::new()
+                .with_no_cache()
+                .with_private(),
         );
     }
 
@@ -214,10 +388,9 @@ mod tests {
     fn test_parse_argument() {
         assert_eq!(
             test_decode::<CacheControl>(&["max-age=100, private"]).unwrap(),
-            CacheControl::new(vec![
-                CacheDirective::max_age(100),
-                CacheDirective::PRIVATE,
-            ]),
+            CacheControl::new()
+                .with_max_age(Duration::from_secs(100))
+                .with_private(),
         );
     }
 
@@ -225,28 +398,62 @@ mod tests {
     fn test_parse_quote_form() {
         assert_eq!(
             test_decode::<CacheControl>(&["max-age=\"200\""]).unwrap(),
-            CacheControl::new(vec![
-                CacheDirective::max_age(200),
-            ]),
+            CacheControl::new()
+                .with_max_age(Duration::from_secs(200)),
         );
     }
 
-    /* TODO
     #[test]
     fn test_parse_extension() {
-        let cache = Header::parse_header(&vec![b"foo, bar=baz".to_vec()].into());
-        assert_eq!(cache.ok(), Some(CacheControl(vec![
-            CacheDirective::Extension("foo".to_owned(), None),
-            CacheDirective::Extension("bar".to_owned(), Some("baz".to_owned()))])))
+        assert_eq!(
+            test_decode::<CacheControl>(&["foo, no-cache, bar=baz"]).unwrap(),
+            CacheControl::new()
+                .with_no_cache(),
+            "unknown extensions are ignored but shouldn't fail parsing",
+        );
     }
-    */
 
     #[test]
     fn test_parse_bad_syntax() {
         assert_eq!(
-            test_decode::<CacheControl>(&["foo="]),
+            test_decode::<CacheControl>(&["max-age=lolz"]),
             None,
         );
+    }
+
+    #[test]
+    fn encode_one_flag_directive() {
+        let cc = CacheControl::new()
+            .with_no_cache();
+
+        let headers = test_encode(cc);
+        assert_eq!(headers["cache-control"], "no-cache");
+    }
+
+    #[test]
+    fn encode_one_param_directive() {
+        let cc = CacheControl::new()
+            .with_max_age(Duration::from_secs(300));
+
+        let headers = test_encode(cc);
+        assert_eq!(headers["cache-control"], "max-age=300");
+    }
+
+    #[test]
+    fn encode_two_directive() {
+        let headers = test_encode(
+            CacheControl::new()
+                .with_no_cache()
+                .with_private()
+        );
+        assert_eq!(headers["cache-control"], "no-cache, private");
+
+        let headers = test_encode(
+            CacheControl::new()
+                .with_no_cache()
+                .with_max_age(Duration::from_secs(100))
+        );
+        assert_eq!(headers["cache-control"], "no-cache, max-age=100");
     }
 }
 

--- a/headers-ext/src/common/mod.rs
+++ b/headers-ext/src/common/mod.rs
@@ -21,7 +21,7 @@ pub use self::access_control_request_headers::AccessControlRequestHeaders;
 pub use self::access_control_request_method::AccessControlRequestMethod;
 pub use self::allow::Allow;
 pub use self::authorization::{Authorization, Credentials, Basic, Bearer};
-pub use self::cache_control::{CacheControl, CacheDirective};
+pub use self::cache_control::CacheControl;
 pub use self::connection::Connection;
 pub use self::content_disposition::ContentDisposition;
 pub use self::content_encoding::ContentEncoding;

--- a/headers-ext/src/lib.rs
+++ b/headers-ext/src/lib.rs
@@ -1,4 +1,6 @@
 extern crate base64;
+#[macro_use]
+extern crate bitflags;
 extern crate bytes;
 extern crate headers_core;
 #[macro_use]

--- a/headers-ext/src/util/seconds.rs
+++ b/headers-ext/src/util/seconds.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use {HeaderValue};
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Seconds(Duration);
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct Seconds(Duration);
 
 impl Seconds {
     pub(crate) fn from_val(val: &HeaderValue) -> Option<Self> {
@@ -15,6 +15,10 @@ impl Seconds {
             .ok()?;
 
         Some(Seconds(Duration::from_secs(secs)))
+    }
+
+    pub(crate) fn as_u64(&self) -> u64 {
+        self.0.as_secs()
     }
 }
 
@@ -33,6 +37,12 @@ impl<'a> From<&'a Seconds> for HeaderValue {
 impl From<Duration> for Seconds {
     fn from(dur: Duration) -> Seconds {
         Seconds(dur)
+    }
+}
+
+impl From<Seconds> for Duration {
+    fn from(secs: Seconds) -> Duration {
+        secs.0
     }
 }
 


### PR DESCRIPTION
I'm not certain if the builder-like design of `with_foo` methods is best, but it works!

Closes #3 