### PR TITLE
Compare Connection header values case-insensitively

### DIFF
--- a/headers-ext/src/common/connection.rs
+++ b/headers-ext/src/common/connection.rs
@@ -78,13 +78,14 @@ impl Connection {
     /// assert!(!conn.contains("close"));
     /// assert!(!conn.contains(UPGRADE));
     /// assert!(conn.contains("keep-alive"));
+    /// assert!(conn.contains("Keep-Alive"));
     /// ```
     pub fn contains(&self, name: impl AsConnectionOption) -> bool {
         let s = name.as_connection_option();
         self
             .0
             .iter()
-            .find(|&opt| opt == s)
+            .find(|&opt| opt.eq_ignore_ascii_case(s))
             .is_some()
     }
 }


### PR DESCRIPTION
I couldn't find where the spec says that they should be case-insensitive, but warp's websocket filter looks for `upgrade` while e.g. Chrome sends `Upgrade`, so the warp websocket doesn't work anymore with Chrome since I upgraded to 0.1.6.