### PR TITLE
Change `name` from const to method

### DIFF
--- a/headers-core/src/lib.rs
+++ b/headers-core/src/lib.rs
@@ -18,7 +18,7 @@ pub use http::header::{self, HeaderName, HeaderValue};
 /// and contains trait-object unsafe methods.
 pub trait Header {
     /// The name of this header.
-    const NAME: &'static HeaderName;
+    fn name() -> &'static HeaderName;
 
     /// Decode this type from an iterator of `HeaderValue`s.
     fn decode<'i, I>(values: &mut I) -> Result<Self, Error>
@@ -111,7 +111,7 @@ impl HeaderMapExt for http::HeaderMap {
         H: Header,
     {
         let entry = self
-            .entry(H::NAME)
+            .entry(H::name())
             .expect("HeaderName is always valid");
         let mut values = ToValues {
             state: State::First(entry),
@@ -131,7 +131,7 @@ impl HeaderMapExt for http::HeaderMap {
     where
         H: Header,
     {
-        let mut values = self.get_all(H::NAME).iter();
+        let mut values = self.get_all(H::name()).iter();
         if values.size_hint() == (0, Some(0)) {
             Ok(None)
         } else {

--- a/headers-derive/src/lib.rs
+++ b/headers-derive/src/lib.rs
@@ -37,7 +37,9 @@ fn impl_header(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
     let dummy_const = Ident::new(&format!("_IMPL_HEADER_FOR_{}", hname), Span::call_site());
     let impl_block = quote! {
         impl __hc::Header for #ty {
-            const NAME: &'static __hc::HeaderName = &__hc::header::#hname_ident;
+            fn name() -> &'static __hc::HeaderName {
+                &__hc::header::#hname_ident
+            }
             fn decode<'i, I>(values: &mut I) -> Result<Self, __hc::Error>
             where
                 I: Iterator<Item = &'i __hc::HeaderValue>,

--- a/src/common/accept_ranges.rs
+++ b/src/common/accept_ranges.rs
@@ -1,7 +1,6 @@
 use util::FlatCsv;
 
-/// `Accept-Ranges` header, defined in
-/// [RFC7233](http://tools.ietf.org/html/rfc7233#section-2.3)
+/// `Accept-Ranges` header, defined in [RFC7233](http://tools.ietf.org/html/rfc7233#section-2.3)
 ///
 /// The `Accept-Ranges` header field allows a server to indicate that it
 /// supports range requests for the target resource.

--- a/src/common/access_control_allow_credentials.rs
+++ b/src/common/access_control_allow_credentials.rs
@@ -34,7 +34,9 @@ use ::{Header, HeaderName, HeaderValue};
 pub struct AccessControlAllowCredentials;
 
 impl Header for AccessControlAllowCredentials {
-    const NAME: &'static HeaderName = &::http::header::ACCESS_CONTROL_ALLOW_CREDENTIALS;
+    fn name() -> &'static HeaderName {
+        &::http::header::ACCESS_CONTROL_ALLOW_CREDENTIALS
+    }
 
     fn decode<'i, I: Iterator<Item = &'i HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values

--- a/src/common/access_control_request_method.rs
+++ b/src/common/access_control_request_method.rs
@@ -29,7 +29,9 @@ use ::{Header, HeaderName, HeaderValue};
 pub struct AccessControlRequestMethod(Method);
 
 impl Header for AccessControlRequestMethod {
-    const NAME: &'static HeaderName = &::http::header::ACCESS_CONTROL_REQUEST_METHOD;
+    fn name() -> &'static HeaderName {
+        &::http::header::ACCESS_CONTROL_REQUEST_METHOD
+    }
 
     fn decode<'i, I: Iterator<Item = &'i HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values.next()

--- a/src/common/authorization.rs
+++ b/src/common/authorization.rs
@@ -60,7 +60,9 @@ impl Authorization<Bearer> {
 }
 
 impl<C: Credentials> ::Header for Authorization<C> {
-    const NAME: &'static ::HeaderName = &::http::header::AUTHORIZATION;
+    fn name() -> &'static ::HeaderName {
+        &::http::header::AUTHORIZATION
+    }
 
     fn decode<'i, I: Iterator<Item = &'i HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values

--- a/src/common/cache_control.rs
+++ b/src/common/cache_control.rs
@@ -185,7 +185,9 @@ impl CacheControl {
 }
 
 impl ::Header for CacheControl {
-    const NAME: &'static ::HeaderName = &::http::header::CACHE_CONTROL;
+    fn name() -> &'static ::HeaderName {
+        &::http::header::CACHE_CONTROL
+    }
 
     fn decode<'i, I: Iterator<Item = &'i HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         csv::from_comma_delimited(values)

--- a/src/common/content_disposition.rs
+++ b/src/common/content_disposition.rs
@@ -91,7 +91,9 @@ impl ContentDisposition {
 }
 
 impl ::Header for ContentDisposition {
-    const NAME: &'static ::HeaderName = &::http::header::CONTENT_DISPOSITION;
+    fn name() -> &'static ::HeaderName {
+        &::http::header::CONTENT_DISPOSITION
+    }
 
     fn decode<'i, I: Iterator<Item = &'i ::HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         //TODO: parse harder

--- a/src/common/content_length.rs
+++ b/src/common/content_length.rs
@@ -41,7 +41,9 @@ use {Header, HeaderValue};
 pub struct ContentLength(pub u64);
 
 impl Header for ContentLength {
-    const NAME: &'static ::http::header::HeaderName = &::http::header::CONTENT_LENGTH;
+    fn name() -> &'static ::http::header::HeaderName {
+        &::http::header::CONTENT_LENGTH
+    }
 
     fn decode<'i, I: Iterator<Item = &'i HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         // If multiple Content-Length headers were sent, everything can still

--- a/src/common/content_range.rs
+++ b/src/common/content_range.rs
@@ -96,7 +96,9 @@ impl ContentRange {
 }
 
 impl ::Header for ContentRange {
-    const NAME: &'static ::HeaderName = &::http::header::CONTENT_RANGE;
+    fn name() -> &'static ::HeaderName {
+        &::http::header::CONTENT_RANGE
+    }
 
     fn decode<'i, I: Iterator<Item = &'i HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values

--- a/src/common/content_type.rs
+++ b/src/common/content_type.rs
@@ -95,7 +95,9 @@ impl ContentType {
 }
 
 impl ::Header for ContentType {
-    const NAME: &'static ::HeaderName = &::http::header::CONTENT_TYPE;
+    fn name() -> &'static ::HeaderName {
+        &::http::header::CONTENT_TYPE
+    }
 
     fn decode<'i, I: Iterator<Item = &'i ::HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values

--- a/src/common/expect.rs
+++ b/src/common/expect.rs
@@ -28,7 +28,9 @@ impl Expect {
 }
 
 impl ::Header for Expect {
-    const NAME: &'static ::HeaderName = &::http::header::EXPECT;
+    fn name() -> &'static ::HeaderName {
+        &::http::header::EXPECT
+    }
 
     fn decode<'i, I: Iterator<Item = &'i ::HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values

--- a/src/common/host.rs
+++ b/src/common/host.rs
@@ -20,7 +20,9 @@ impl Host {
 }
 
 impl ::Header for Host {
-    const NAME: &'static ::HeaderName = &::http::header::HOST;
+    fn name() -> &'static ::HeaderName {
+        &::http::header::HOST
+    }
 
     fn decode<'i, I: Iterator<Item = &'i ::HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -73,7 +73,7 @@ fn test_decode<T: ::headers_core::Header>(values: &[&str]) -> Option<T> {
     use ::headers_core::HeaderMapExt;
     let mut map = ::http::HeaderMap::new();
     for val in values {
-        map.append(T::NAME, val.parse().unwrap());
+        map.append(T::name(), val.parse().unwrap());
     }
     map.typed_get()
 }

--- a/src/common/proxy_authorization.rs
+++ b/src/common/proxy_authorization.rs
@@ -25,7 +25,9 @@ use super::authorization::{Authorization, Credentials};
 pub struct ProxyAuthorization<C: Credentials>(pub C);
 
 impl<C: Credentials> ::Header for ProxyAuthorization<C> {
-    const NAME: &'static ::HeaderName = &::http::header::PROXY_AUTHORIZATION;
+    fn name() -> &'static ::HeaderName {
+        &::http::header::PROXY_AUTHORIZATION
+    }
 
     fn decode<'i, I: Iterator<Item = &'i ::HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         Authorization::decode(values)

--- a/src/common/range.rs
+++ b/src/common/range.rs
@@ -83,7 +83,9 @@ fn parse_bound(s: &str) -> Option<Bound<u64>> {
 }
 
 impl ::Header for Range {
-    const NAME: &'static ::HeaderName = &::http::header::RANGE;
+    fn name() -> &'static ::HeaderName {
+        &::http::header::RANGE
+    }
 
     fn decode<'i, I: Iterator<Item = &'i ::HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values

--- a/src/common/sec_websocket_version.rs
+++ b/src/common/sec_websocket_version.rs
@@ -8,7 +8,9 @@ impl SecWebsocketVersion {
 }
 
 impl ::Header for SecWebsocketVersion {
-    const NAME: &'static ::HeaderName = &::http::header::SEC_WEBSOCKET_VERSION;
+    fn name() -> &'static ::HeaderName {
+        &::http::header::SEC_WEBSOCKET_VERSION
+    }
 
     fn decode<'i, I: Iterator<Item = &'i ::HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values

--- a/src/common/set_cookie.rs
+++ b/src/common/set_cookie.rs
@@ -56,7 +56,9 @@
 pub struct SetCookie(Vec<::HeaderValue>);
 
 impl ::Header for SetCookie {
-    const NAME: &'static ::HeaderName = &::http::header::SET_COOKIE;
+    fn name() -> &'static ::HeaderName {
+        &::http::header::SET_COOKIE
+    }
 
     fn decode<'i, I: Iterator<Item = &'i ::HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         let vec = values

--- a/src/common/strict_transport_security.rs
+++ b/src/common/strict_transport_security.rs
@@ -117,7 +117,9 @@ fn from_str(s: &str) -> Result<StrictTransportSecurity, ::Error> {
 }
 
 impl ::Header for StrictTransportSecurity {
-    const NAME: &'static ::HeaderName = &::http::header::STRICT_TRANSPORT_SECURITY;
+    fn name() -> &'static ::HeaderName {
+        &::http::header::STRICT_TRANSPORT_SECURITY
+    }
 
     fn decode<'i, I: Iterator<Item = &'i ::HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,9 @@
 //! struct Dnt(bool);
 //!
 //! impl Header for Dnt {
-//!     const NAME: &'static HeaderName = &http::header::DNT;
+//!     fn name() -> &'static HeaderName {
+//!          &http::header::DNT
+//!     }
 //!
 //!     fn decode<'i, I>(values: &mut I) -> Result<Self, headers::Error>
 //!     where
@@ -72,6 +74,7 @@ extern crate base64;
 #[macro_use]
 extern crate bitflags;
 extern crate bytes;
+#[macro_use]
 extern crate headers_core;
 #[macro_use]
 extern crate headers_derive;


### PR DESCRIPTION
(Note: this PR builds off #32. The diff is noisier than it would be otherwise.)

Anyways: this PR changes the `Header` trait's `const NAME: &'static HeaderName` to a `fn name() -> &'static HeaderName`. Therefore, the header trait now looks like:

```rust
pub trait Header {
    /// The name of this header.
    fn name() -> &'static HeaderName;

    /// Decode this type from an iterator of `HeaderValue`s.
    fn decode<'i, I>(values: &mut I) -> Result<Self, Error>
    where
        Self: Sized,
        I: Iterator<Item = &'i HeaderValue>;

    /// Encode this type to a `HeaderMap`.
    ///
    /// This function should be infallible. Any errors converting to a
    /// `HeaderValue` should have been caught when parsing or constructing
    /// this value.
    fn encode<E: Extend<HeaderValue>>(&self, values: &mut E);
}
```

This makes supporting custom typed headers _far_ easier and doesn't require the use of error-prone macros like `standard_headers` that expose `HeaderName` internals the `hyperium/http` crate. In a future version of `http` or `headers`, the `fn name() -> &'static HeaderName` can be deprecated and replaced with a `const`. Hopefully, this deprecation will come when Rust supports short-circuiting logic in `const fn`.