### PR TITLE
Change from sha-1 to sha1 and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headers"
-version = "0.2.1" # don't forget to update html_root_url
+version = "0.2.2" # don't forget to update html_root_url
 description = "typed HTTP headers"
 license = "MIT"
 readme = "README.md"
@@ -25,7 +25,7 @@ base64 = "0.10"
 bitflags = "1.0"
 bytes = "0.4"
 mime = "0.3"
-sha-1 = "0.8"
+sha1 = "0.6"
 time = "0.1"
 
 [features]

--- a/src/common/sec_websocket_accept.rs
+++ b/src/common/sec_websocket_accept.rs
@@ -1,6 +1,6 @@
 use base64;
 use bytes::Bytes;
-use sha1::{Digest, Sha1};
+use sha1::Sha1;
 
 use super::SecWebsocketKey;
 
@@ -32,9 +32,9 @@ impl From<SecWebsocketKey> for SecWebsocketAccept {
 
 fn sign(key: &[u8]) -> SecWebsocketAccept {
     let mut sha1 = Sha1::default();
-    sha1.input(key);
-    sha1.input(&b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"[..]);
-    let b64 = Bytes::from(base64::encode(&sha1.result()));
+    sha1.update(key);
+    sha1.update(&b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"[..]);
+    let b64 = Bytes::from(base64::encode(&sha1.digest().bytes()));
 
     let val = ::HeaderValue::from_shared(b64)
         .expect("base64 is a valid value");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
-#![doc(html_root_url = "https://docs.rs/headers/0.2.1")]
+#![doc(html_root_url = "https://docs.rs/headers/0.2.2")]
 
 //! # Typed HTTP Headers
 //!


### PR DESCRIPTION
The former isn't maintained and depends on lots of old dependencies
meaning that there are tons of duplicates in projects depending on
headers and any other hashing related library (sha2 for example).