### PR TITLE
Disable the headers-derive proc macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ categories = ["web-programming"]
 members = [
     "./",
     "headers-core",
-    "headers-derive",
+    #"headers-derive",
 ]
 
 [dependencies]
 http = "0.1.15"
 headers-core = { version = "0.1", path = "./headers-core" }
-headers-derive = { version = "0.1", path = "./headers-derive" }
+#headers-derive = { version = "0.1", path = "./headers-derive" }
 base64 = "0.10"
 bitflags = "1.0"
 bytes = "0.4"

--- a/src/common/accept_ranges.rs
+++ b/src/common/accept_ranges.rs
@@ -26,8 +26,13 @@ use util::FlatCsv;
 ///
 /// headers.typed_insert(AcceptRanges::bytes());
 /// ```
-#[derive(Clone, Debug, Header, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct AcceptRanges(FlatCsv);
+
+derive_header! {
+    AcceptRanges(_),
+    name: ACCEPT_RANGES
+}
 
 impl AcceptRanges {
     /// A constructor to easily create the common `Accept-Ranges: bytes` header.

--- a/src/common/access_control_allow_headers.rs
+++ b/src/common/access_control_allow_headers.rs
@@ -31,8 +31,13 @@ use util::FlatCsv;
 ///     .into_iter()
 ///     .collect::<AccessControlAllowHeaders>();
 /// ```
-#[derive(Clone, Debug, PartialEq, Header)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct AccessControlAllowHeaders(FlatCsv);
+
+derive_header! {
+    AccessControlAllowHeaders(_),
+    name: ACCESS_CONTROL_ALLOW_HEADERS
+}
 
 impl AccessControlAllowHeaders {
     /// Returns an iterator over `HeaderName`s contained within.

--- a/src/common/access_control_allow_methods.rs
+++ b/src/common/access_control_allow_methods.rs
@@ -32,8 +32,13 @@ use util::FlatCsv;
 ///     .into_iter()
 ///     .collect::<AccessControlAllowMethods>();
 /// ```
-#[derive(Clone, Debug, PartialEq, Header)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct AccessControlAllowMethods(FlatCsv);
+
+derive_header! {
+    AccessControlAllowMethods(_),
+    name: ACCESS_CONTROL_ALLOW_METHODS
+}
 
 impl AccessControlAllowMethods {
     /// Returns an iterator over `Method`s contained within.

--- a/src/common/access_control_allow_origin.rs
+++ b/src/common/access_control_allow_origin.rs
@@ -29,8 +29,13 @@ use super::origin::{Origin};
 /// let any_origin = AccessControlAllowOrigin::ANY;
 /// let null_origin = AccessControlAllowOrigin::NULL;
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Header)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct AccessControlAllowOrigin(OriginOrAny);
+
+derive_header! {
+    AccessControlAllowOrigin(_),
+    name: ACCESS_CONTROL_ALLOW_ORIGIN
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum OriginOrAny {

--- a/src/common/access_control_expose_headers.rs
+++ b/src/common/access_control_expose_headers.rs
@@ -32,8 +32,13 @@ use util::FlatCsv;
 ///     .collect::<AccessControlExposeHeaders>();
 /// # }
 /// ```
-#[derive(Clone, Debug, Header)]
+#[derive(Clone, Debug)]
 pub struct AccessControlExposeHeaders(FlatCsv);
+
+derive_header! {
+    AccessControlExposeHeaders(_),
+    name: ACCESS_CONTROL_EXPOSE_HEADERS
+}
 
 impl AccessControlExposeHeaders {
     /// Returns an iterator over `HeaderName`s contained within.

--- a/src/common/access_control_max_age.rs
+++ b/src/common/access_control_max_age.rs
@@ -27,8 +27,13 @@ use util::Seconds;
 ///
 /// let max_age = AccessControlMaxAge::from(Duration::from_secs(531));
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Header)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AccessControlMaxAge(Seconds);
+
+derive_header! {
+    AccessControlMaxAge(_),
+    name: ACCESS_CONTROL_MAX_AGE
+}
 
 impl From<Duration> for AccessControlMaxAge {
     fn from(dur: Duration) -> AccessControlMaxAge {

--- a/src/common/access_control_request_headers.rs
+++ b/src/common/access_control_request_headers.rs
@@ -33,8 +33,13 @@ use util::FlatCsv;
 ///     .collect::<AccessControlRequestHeaders>();
 /// # }
 /// ```
-#[derive(Clone, Debug, Header)]
+#[derive(Clone, Debug)]
 pub struct AccessControlRequestHeaders(FlatCsv);
+
+derive_header! {
+    AccessControlRequestHeaders(_),
+    name: ACCESS_CONTROL_REQUEST_HEADERS
+}
 
 impl AccessControlRequestHeaders {
     /// Returns an iterator over `HeaderName`s contained within.

--- a/src/common/allow.rs
+++ b/src/common/allow.rs
@@ -34,8 +34,13 @@ use util::FlatCsv;
 ///     .into_iter()
 ///     .collect::<Allow>();
 /// ```
-#[derive(Clone, Debug, PartialEq, Header)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Allow(FlatCsv);
+
+derive_header! {
+    Allow(_),
+    name: ALLOW
+}
 
 impl Allow {
     /// Returns an iterator over `Method`s contained within.

--- a/src/common/connection.rs
+++ b/src/common/connection.rs
@@ -34,8 +34,13 @@ use self::sealed::AsConnectionOption;
 /// let keep_alive = Connection::keep_alive();
 /// ```
 // This is frequently just 1 or 2 values, so optimize for that case.
-#[derive(Clone, Debug, Header)]
+#[derive(Clone, Debug)]
 pub struct Connection(FlatCsv);
+
+derive_header! {
+    Connection(_),
+    name: CONNECTION
+}
 
 impl Connection {
     /// A constructor to easily create a `Connection: close` header.

--- a/src/common/content_encoding.rs
+++ b/src/common/content_encoding.rs
@@ -31,8 +31,13 @@ use self::sealed::AsCoding;
 ///
 /// let content_enc = ContentEncoding::gzip();
 /// ```
-#[derive(Clone, Debug, Header)]
+#[derive(Clone, Debug)]
 pub struct ContentEncoding(FlatCsv);
+
+derive_header! {
+    ContentEncoding(_),
+    name: CONTENT_ENCODING
+}
 
 impl ContentEncoding {
     /// A constructor to easily create a `Content-Encoding: gzip` header.

--- a/src/common/content_location.rs
+++ b/src/common/content_location.rs
@@ -24,9 +24,13 @@ use ::HeaderValue;
 ///
 /// # Examples
 ///
-//TODO: make this a `Uri`?
-#[derive(Clone, Debug, PartialEq, Header)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ContentLocation(HeaderValue);
+
+derive_header! {
+    ContentLocation(_),
+    name: CONTENT_LOCATION
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/common/cookie.rs
+++ b/src/common/cookie.rs
@@ -14,8 +14,13 @@ use util::{FlatCsv, SemiColon};
 /// * `SID=31d4d96e407aad42`
 /// * `SID=31d4d96e407aad42; lang=en-US`
 ///
-#[derive(Clone, Debug, Header)]
+#[derive(Clone, Debug)]
 pub struct Cookie(FlatCsv<SemiColon>);
+
+derive_header! {
+    Cookie(_),
+    name: COOKIE
+}
 
 impl Cookie {
     /// Lookup a value for a cookie name.

--- a/src/common/date.rs
+++ b/src/common/date.rs
@@ -25,8 +25,13 @@ use util::HttpDate;
 ///
 /// let date = Date::from(SystemTime::now());
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Header)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Date(HttpDate);
+
+derive_header! {
+    Date(_),
+    name: DATE
+}
 
 impl From<SystemTime> for Date {
     fn from(time: SystemTime) -> Date {

--- a/src/common/etag.rs
+++ b/src/common/etag.rs
@@ -26,9 +26,13 @@ use util::EntityTag;
 ///
 /// # Examples
 ///
-#[derive(Clone, Debug, PartialEq, Eq, Header)]
-#[header(name_const = "ETAG")]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ETag(pub(super) EntityTag);
+
+derive_header! {
+    ETag(_),
+    name: ETAG
+}
 
     /*
     test_etag {

--- a/src/common/expires.rs
+++ b/src/common/expires.rs
@@ -29,8 +29,13 @@ use util::HttpDate;
 /// let time = SystemTime::now() + Duration::from_secs(60 * 60 * 24);
 /// let expires = Expires::from(time);
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Header)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Expires(HttpDate);
+
+derive_header! {
+    Expires(_),
+    name: EXPIRES
+}
 
 impl From<SystemTime> for Expires {
     fn from(time: SystemTime) -> Expires {

--- a/src/common/if_match.rs
+++ b/src/common/if_match.rs
@@ -36,8 +36,13 @@ use util::FlatCsv;
 ///
 /// let if_match = IfMatch::any();
 /// ```
-#[derive(Clone, Debug, PartialEq, Header)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct IfMatch(FlatCsv);
+
+derive_header! {
+    IfMatch(_),
+    name: IF_MATCH
+}
 
 impl IfMatch {
     /// Create a new `If-Match: *` header.

--- a/src/common/if_modified_since.rs
+++ b/src/common/if_modified_since.rs
@@ -29,8 +29,13 @@ use util::HttpDate;
 /// let time = SystemTime::now() - Duration::from_secs(60 * 60 * 24);
 /// let if_mod = IfModifiedSince::from(time);
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Header)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IfModifiedSince(HttpDate);
+
+derive_header! {
+    IfModifiedSince(_),
+    name: IF_MODIFIED_SINCE
+}
 
 impl IfModifiedSince {
     /// Check if the supplied time means the resource has been modified.

--- a/src/common/if_none_match.rs
+++ b/src/common/if_none_match.rs
@@ -38,8 +38,13 @@ use {HeaderValue};
 ///
 /// let if_none_match = IfNoneMatch::any();
 /// ```
-#[derive(Clone, Debug, PartialEq, Header)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct IfNoneMatch(FlatCsv);
+
+derive_header! {
+    IfNoneMatch(_),
+    name: IF_NONE_MATCH
+}
 
 impl IfNoneMatch {
     /// Create a new `If-None-Match: *` header.

--- a/src/common/if_range.rs
+++ b/src/common/if_range.rs
@@ -40,8 +40,13 @@ use super::{LastModified, ETag};
 /// let fetched = SystemTime::now() - Duration::from_secs(60 * 60 * 24);
 /// let if_range = IfRange::date(fetched);
 /// ```
-#[derive(Clone, Debug, PartialEq, Header)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct IfRange(IfRange_);
+
+derive_header! {
+    IfRange(_),
+    name: IF_RANGE
+}
 
 impl IfRange {
     /// Create an `IfRange` header with an entity tag.

--- a/src/common/if_unmodified_since.rs
+++ b/src/common/if_unmodified_since.rs
@@ -30,8 +30,13 @@ use util::HttpDate;
 /// let time = SystemTime::now() - Duration::from_secs(60 * 60 * 24);
 /// let if_unmod = IfUnmodifiedSince::from(time);
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Header)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IfUnmodifiedSince(HttpDate);
+
+derive_header! {
+    IfUnmodifiedSince(_),
+    name: IF_UNMODIFIED_SINCE
+}
 
 impl IfUnmodifiedSince {
     /// Check if the supplied time passes the precondtion.

--- a/src/common/last_modified.rs
+++ b/src/common/last_modified.rs
@@ -30,8 +30,13 @@ use util::HttpDate;
 ///     SystemTime::now() - Duration::from_secs(60 * 60 * 24)
 /// );
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Header)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LastModified(pub(super) HttpDate);
+
+derive_header! {
+    LastModified(_),
+    name: LAST_MODIFIED
+}
 
 impl From<SystemTime> for LastModified {
     fn from(time: SystemTime) -> LastModified {

--- a/src/common/location.rs
+++ b/src/common/location.rs
@@ -20,9 +20,13 @@ use ::HeaderValue;
 ///
 /// # Examples
 ///
-//TODO: make this a `Uri`?
-#[derive(Clone, Debug, PartialEq, Header)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Location(HeaderValue);
+
+derive_header! {
+    Location(_),
+    name: LOCATION
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/common/origin.rs
+++ b/src/common/origin.rs
@@ -24,8 +24,13 @@ use ::{HeaderValue};
 ///
 /// let origin = Origin::NULL;
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Header)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Origin(OriginOrNull);
+
+derive_header! {
+    Origin(_),
+    name: ORIGIN
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum OriginOrNull {

--- a/src/common/pragma.rs
+++ b/src/common/pragma.rs
@@ -23,8 +23,13 @@ use ::HeaderValue;
 ///
 /// let pragma = Pragma::no_cache();
 /// ```
-#[derive(Clone, Debug, PartialEq, Header)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Pragma(HeaderValue);
+
+derive_header! {
+    Pragma(_),
+    name: PRAGMA
+}
 
 impl Pragma {
     /// Construct the literal `no-cache` Pragma header.

--- a/src/common/referer.rs
+++ b/src/common/referer.rs
@@ -29,8 +29,13 @@ use http::header::HeaderValue;
 ///
 /// let r = Referer::from_static("/People.html#tim");
 /// ```
-#[derive(Debug, Clone, PartialEq, Header)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Referer(HeaderValue);
+
+derive_header! {
+    Referer(_),
+    name: REFERER
+}
 
 impl Referer {
     /// Create a `Referer` with a static string.

--- a/src/common/referrer_policy.rs
+++ b/src/common/referrer_policy.rs
@@ -30,8 +30,13 @@ use {HeaderValue};
 ///
 /// let rp = ReferrerPolicy::NO_REFERRER;
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Header)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ReferrerPolicy(Policy);
+
+derive_header! {
+    ReferrerPolicy(_),
+    name: REFERRER_POLICY
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum Policy {

--- a/src/common/retry_after.rs
+++ b/src/common/retry_after.rs
@@ -24,8 +24,13 @@ use ::HeaderValue;
 /// ```
 
 /// Retry-After header, defined in [RFC7231](http://tools.ietf.org/html/rfc7231#section-7.1.3)
-#[derive(Debug, Clone, PartialEq, Eq, Header)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RetryAfter(After);
+
+derive_header! {
+    RetryAfter(_),
+    name: RETRY_AFTER
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum After {

--- a/src/common/sec_websocket_accept.rs
+++ b/src/common/sec_websocket_accept.rs
@@ -21,8 +21,13 @@ use super::SecWebsocketKey;
 ///
 /// let sec_accept = SecWebsocketAccept::from(sec_key);
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Header)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct SecWebsocketAccept(::HeaderValue);
+
+derive_header! {
+    SecWebsocketAccept(_),
+    name: SEC_WEBSOCKET_ACCEPT
+}
 
 impl From<SecWebsocketKey> for SecWebsocketAccept {
     fn from(key: SecWebsocketKey) -> SecWebsocketAccept {

--- a/src/common/sec_websocket_key.rs
+++ b/src/common/sec_websocket_key.rs
@@ -1,5 +1,8 @@
 /// The `Sec-Websocket-Key` header.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Header)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct SecWebsocketKey(pub(super) ::HeaderValue);
 
-
+derive_header! {
+    SecWebsocketKey(_),
+    name: SEC_WEBSOCKET_KEY
+}

--- a/src/common/server.rs
+++ b/src/common/server.rs
@@ -30,8 +30,13 @@ use util::HeaderValueString;
 ///
 /// let server = Server::from_static("hyper/0.12.2");
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Header)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Server(HeaderValueString);
+
+derive_header! {
+    Server(_),
+    name: SERVER
+}
 
 impl Server {
     /// Construct a `Server` from a static string.

--- a/src/common/te.rs
+++ b/src/common/te.rs
@@ -25,8 +25,13 @@ use util::FlatCsv;
 ///
 /// # Examples
 ///
-#[derive(Clone, Debug, PartialEq, Header)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Te(FlatCsv);
+
+derive_header! {
+    Te(_),
+    name: TE
+}
 
 impl Te {
     /// Create a `TE: trailers` header.

--- a/src/common/transfer_encoding.rs
+++ b/src/common/transfer_encoding.rs
@@ -38,8 +38,13 @@ use ::HeaderValue;
 // This currently is just a `HeaderValue`, instead of a `Vec<Encoding>`, since
 // the most common by far instance is simply the string `chunked`. It'd be a
 // waste to need to allocate just for that.
-#[derive(Clone, Debug, Header)]
+#[derive(Clone, Debug)]
 pub struct TransferEncoding(FlatCsv);
+
+derive_header! {
+    TransferEncoding(_),
+    name: TRANSFER_ENCODING
+}
 
 impl TransferEncoding {
     /// Constructor for the most common Transfer-Encoding, `chunked`.

--- a/src/common/upgrade.rs
+++ b/src/common/upgrade.rs
@@ -39,8 +39,13 @@ use ::HeaderValue;
 ///
 /// let ws = Upgrade::websocket();
 /// ```
-#[derive(Clone, Debug, PartialEq, Header)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Upgrade(HeaderValue);
+
+derive_header! {
+    Upgrade(_),
+    name: UPGRADE
+}
 
 impl Upgrade {
     /// Constructs an `Upgrade: websocket` header.

--- a/src/common/user_agent.rs
+++ b/src/common/user_agent.rs
@@ -39,8 +39,13 @@ use util::HeaderValueString;
 ///
 /// let ua = UserAgent::from_static("hyper/0.12.2");
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Header)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UserAgent(HeaderValueString);
+
+derive_header! {
+    UserAgent(_),
+    name: USER_AGENT
+}
 
 impl UserAgent {
     /// Create a `UserAgent` from a static string.

--- a/src/common/vary.rs
+++ b/src/common/vary.rs
@@ -29,8 +29,14 @@ use {HeaderValue};
 ///
 /// let vary = Vary::any();
 /// ```
-#[derive(Debug, Clone, PartialEq, Header)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Vary(FlatCsv);
+
+derive_header! {
+    Vary(_),
+    name: VARY
+}
+
 
 impl Vary {
     /// Create a new `Very: *` header.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,8 +78,6 @@ extern crate base64;
 extern crate bitflags;
 extern crate bytes;
 extern crate headers_core;
-#[macro_use]
-extern crate headers_derive;
 extern crate http;
 extern crate mime;
 extern crate sha1;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -52,6 +52,28 @@ macro_rules! error_type {
     );
 }
 
+macro_rules! derive_header {
+    ($type:ident(_), name: $name:ident) => (
+        impl crate::Header for $type {
+            fn name() -> &'static ::http::header::HeaderName {
+                &::http::header::$name
+            }
+
+            fn decode<'i, I>(values: &mut I) -> Result<Self, ::Error>
+            where
+                I: Iterator<Item = &'i ::http::header::HeaderValue>,
+            {
+                ::util::TryFromValues::try_from_values(values)
+                    .map($type)
+            }
+
+            fn encode<E: Extend<::HeaderValue>>(&self, values: &mut E) {
+                values.extend(::std::iter::once((&self.0).into()));
+            }
+        }
+    );
+}
+
 /// A helper trait for use when deriving `Header`.
 pub(crate) trait TryFromValues: Sized {
     /// Try to convert from the values into an instance of `Self`.


### PR DESCRIPTION
It's not that helpful versus a macro-by-example, and so removing it should improve compile times.