### PR TITLE
chore: bump version to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headers"
-version = "0.2.3" # don't forget to update html_root_url
+version = "0.3.0" # don't forget to update html_root_url
 description = "typed HTTP headers"
 license = "MIT"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
-#![doc(html_root_url = "https://docs.rs/headers/0.2.3")]
+#![doc(html_root_url = "https://docs.rs/headers/0.3.0")]
 
 //! # Typed HTTP Headers
 //!


### PR DESCRIPTION
This follows as a result of bumping the versions of http and bytes.

A new release of this crate will be needed in order to support users (e.g. warp) that want to work on the stable async ecosystem, which rely on the aforementioned new versions of http and bytes.