### PR TITLE
Increase dependency versions to real minimal versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ headers-core = { version = "0.2", path = "./headers-core" }
 base64 = "0.11"
 bitflags = "1.0"
 bytes = "0.5"
-mime = "0.3"
+mime = "0.3.14"
 sha-1 = "0.8"
-time = "0.1"
+time = "0.1.34"
 
 [features]
 nightly = []


### PR DESCRIPTION
This helps with `-Z minimal-versions` builds. Yeah, this option is kind of a meme, but doesn't stop me from suggesting improvements.