### PR TITLE
Accept-Encoding Header + small update to Content-Encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ headers-core = { version = "0.2", path = "./headers-core" }
 base64 = "0.12"
 bitflags = "1.0"
 bytes = "0.5"
+itertools = "0.9"
 mime = "0.3.14"
 sha-1 = "0.8"
 time = "0.1.34"

--- a/src/common/accept_encoding.rs
+++ b/src/common/accept_encoding.rs
@@ -1,0 +1,14 @@
+use util::QualityValue;
+// use HeaderValue;
+
+
+/// `Accept-Encoding` header, defined in
+/// [RFC7231](https://tools.ietf.org/html/rfc7231#section-5.3.4)
+/// 
+#[derive(Clone, Debug)]
+pub struct AcceptEncoding(QualityValue);
+
+derive_header! {
+    AcceptEncoding(_),
+    name: ACCEPT_ENCODING
+}

--- a/src/common/accept_encoding.rs
+++ b/src/common/accept_encoding.rs
@@ -1,14 +1,134 @@
-use util::QualityValue;
-// use HeaderValue;
-
+use std::convert::TryFrom;
+use util::{QualityValue, TryFromValues};
+use HeaderValue;
 
 /// `Accept-Encoding` header, defined in
 /// [RFC7231](https://tools.ietf.org/html/rfc7231#section-5.3.4)
-/// 
+///
+/// The `Accept-Encoding` header field can be used by user agents to
+/// indicate what response content-codings are acceptable in the response.
+/// An "identity" token is used as a synonym for "no encoding" in
+/// order to communicate when no encoding is preferred.
+///
+/// # ABNF
+///
+/// ```text
+/// Accept-Encoding  = #( codings [ weight ] )
+/// codings          = content-coding / "identity" / "*"
+/// ```
+///
+/// # Example Values
+///
+/// * `gzip`
+/// * `br;q=1.0, gzip;q=0.8`
+///
 #[derive(Clone, Debug)]
 pub struct AcceptEncoding(QualityValue);
 
 derive_header! {
     AcceptEncoding(_),
     name: ACCEPT_ENCODING
+}
+
+impl AcceptEncoding {
+    /// Convience method
+    #[inline]
+    pub fn gzip() -> AcceptEncoding {
+        AcceptEncoding(HeaderValue::from_static("gzip").into())
+    }
+
+    /// A convience method to create an Accept-Encoding header from pairs of values and qualities
+    /// 
+    /// # Example 
+    /// 
+    /// ```
+    /// use headers::AcceptEncoding;
+    /// 
+    /// let pairs = vec![("gzip", 1.0), ("deflate", 0.8)];
+    /// let header = AcceptEncoding::from_quality_pairs(&mut pairs.into_iter());
+    /// ```
+    pub fn from_quality_pairs<'i, I>(pairs: &mut I) -> Result<AcceptEncoding, ::Error>
+    where
+        I: Iterator<Item = (&'i str, f32)>,
+    {
+        let values: Vec<HeaderValue> = pairs
+            .map(|pair| {
+                QualityValue::try_from(pair).map(|qual: QualityValue| HeaderValue::from(qual))
+            })
+            .collect::<Result<Vec<HeaderValue>, ::Error>>()?;
+        let value = QualityValue::try_from_values(&mut values.iter())?;
+        Ok(AcceptEncoding(value))
+    }
+
+    /// Returns the most prefered encoding that is specified by the client,
+    /// if one is specified.
+    ///
+    /// Note: This peeks at the underlying iter, not modifying it.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use headers::AcceptEncoding;
+    ///
+    /// let pairs = vec![("gzip", 1.0), ("deflate", 0.8)];
+    /// let accept_enc = AcceptEncoding::from_quality_pairs(&mut pairs.into_iter()).unwrap();
+    /// let mut encodings = accept_enc.sorted_encodings();
+    ///
+    /// assert_eq!(accept_enc.prefered_encoding(), Some("gzip"));
+    /// ```
+    pub fn prefered_encoding(&self) -> Option<&str> {
+        self.0.iter().peekable().peek().map(|s| *s)
+    }
+
+    /// Returns a quality sorted iterator of the accepted encodings
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use headers::{AcceptEncoding, HeaderValue};
+    ///
+    /// let pairs = vec![("gzip", 1.0), ("deflate", 0.8)];
+    /// let accept_enc = AcceptEncoding::from_quality_pairs(&mut pairs.into_iter()).unwrap();
+    /// let mut encodings = accept_enc.sorted_encodings();
+    ///
+    /// assert_eq!(encodings.next(), Some("gzip"));
+    /// assert_eq!(encodings.next(), Some("deflate"));
+    /// assert_eq!(encodings.next(), None);
+    /// ```
+    pub fn sorted_encodings(&self) -> impl Iterator<Item = &str> {
+        self.0.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use HeaderValue;
+
+    #[test]
+    fn from_static() {
+        let val = HeaderValue::from_static("deflate, gzip;q=1.0, br;q=0.9");
+        let accept_enc = AcceptEncoding(val.into());
+
+        assert_eq!(accept_enc.prefered_encoding(), Some("deflate"));
+
+        let mut encodings = accept_enc.sorted_encodings();
+        assert_eq!(encodings.next(), Some("deflate"));
+        assert_eq!(encodings.next(), Some("gzip"));
+        assert_eq!(encodings.next(), Some("br"));
+        assert_eq!(encodings.next(), None);
+    }
+
+    #[test]
+    fn from_pairs() {
+        let pairs = vec![("gzip", 1.0), ("br", 0.9)];
+        let accept_enc = AcceptEncoding::from_quality_pairs(&mut pairs.into_iter()).unwrap();
+
+        assert_eq!(accept_enc.prefered_encoding(), Some("gzip"));
+
+        let mut encodings = accept_enc.sorted_encodings();
+        assert_eq!(encodings.next(), Some("gzip"));
+        assert_eq!(encodings.next(), Some("br"));
+        assert_eq!(encodings.next(), None);
+    }
 }

--- a/src/common/accept_encoding.rs
+++ b/src/common/accept_encoding.rs
@@ -31,19 +31,19 @@ derive_header! {
 }
 
 impl AcceptEncoding {
-    /// Convience method
+    /// Convience method to create an `Accept-Encoding: gzip` header
     #[inline]
     pub fn gzip() -> AcceptEncoding {
         AcceptEncoding(HeaderValue::from_static("gzip").into())
     }
 
     /// A convience method to create an Accept-Encoding header from pairs of values and qualities
-    /// 
-    /// # Example 
-    /// 
+    ///
+    /// # Example
+    ///
     /// ```
     /// use headers::AcceptEncoding;
-    /// 
+    ///
     /// let pairs = vec![("gzip", 1.0), ("deflate", 0.8)];
     /// let header = AcceptEncoding::from_quality_pairs(&mut pairs.into_iter());
     /// ```
@@ -60,7 +60,7 @@ impl AcceptEncoding {
         Ok(AcceptEncoding(value))
     }
 
-    /// Returns the most prefered encoding that is specified by the client,
+    /// Returns the most prefered encoding that is specified by the header,
     /// if one is specified.
     ///
     /// Note: This peeks at the underlying iter, not modifying it.

--- a/src/common/accept_encoding.rs
+++ b/src/common/accept_encoding.rs
@@ -23,7 +23,7 @@ use HeaderValue;
 /// * `br;q=1.0, gzip;q=0.8`
 ///
 #[derive(Clone, Debug)]
-pub struct AcceptEncoding(QualityValue);
+pub struct AcceptEncoding(pub QualityValue);
 
 derive_header! {
     AcceptEncoding(_),
@@ -87,12 +87,13 @@ impl AcceptEncoding {
     /// ```
     /// use headers::{AcceptEncoding, HeaderValue};
     ///
-    /// let pairs = vec![("gzip", 1.0), ("deflate", 0.8)];
-    /// let accept_enc = AcceptEncoding::from_quality_pairs(&mut pairs.into_iter()).unwrap();
+    /// let val = HeaderValue::from_static("deflate, gzip;q=1.0, br;q=0.8");
+    /// let accept_enc = AcceptEncoding(val.into());
     /// let mut encodings = accept_enc.sorted_encodings();
     ///
-    /// assert_eq!(encodings.next(), Some("gzip"));
     /// assert_eq!(encodings.next(), Some("deflate"));
+    /// assert_eq!(encodings.next(), Some("gzip"));
+    /// assert_eq!(encodings.next(), Some("br"));
     /// assert_eq!(encodings.next(), None);
     /// ```
     pub fn sorted_encodings(&self) -> impl Iterator<Item = &str> {

--- a/src/common/content_encoding.rs
+++ b/src/common/content_encoding.rs
@@ -46,6 +46,30 @@ impl ContentEncoding {
         ContentEncoding(HeaderValue::from_static("gzip").into())
     }
 
+    /// A constructor to easily create a `Content-Encoding: compress` header.
+    #[inline]
+    pub fn compress() -> ContentEncoding {
+        ContentEncoding(HeaderValue::from_static("compress").into())
+    }
+
+    /// A constructor to easily create a `Content-Encoding: deflate` header.
+    #[inline]
+    pub fn deflate() -> ContentEncoding {
+        ContentEncoding(HeaderValue::from_static("deflate").into())
+    }
+
+    /// A constructor to easily create a `Content-Encoding: identity` header.
+    #[inline]
+    pub fn identity() -> ContentEncoding {
+        ContentEncoding(HeaderValue::from_static("identity").into())
+    }
+
+    /// A constructor to easily create a `Content-Encoding: br` header.
+    #[inline]
+    pub fn br() -> ContentEncoding {
+        ContentEncoding(HeaderValue::from_static("br").into())
+    }
+
     /// Check if this header contains a given "coding".
     ///
     /// This can be used with these argument types:

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -7,7 +7,7 @@
 //! is used, such as `ContentType(pub Mime)`.
 
 //pub use self::accept_charset::AcceptCharset;
-//pub use self::accept_encoding::AcceptEncoding;
+pub use self::accept_encoding::AcceptEncoding;
 //pub use self::accept_language::AcceptLanguage;
 pub use self::accept_ranges::AcceptRanges;
 //pub use self::accept::Accept;
@@ -127,7 +127,7 @@ macro_rules! bench_header {
 
 //mod accept;
 //mod accept_charset;
-//mod accept_encoding;
+mod accept_encoding;
 //mod accept_language;
 mod accept_ranges;
 mod access_control_allow_credentials;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ extern crate bitflags;
 extern crate bytes;
 extern crate headers_core;
 extern crate http;
+extern crate itertools;
 extern crate mime;
 extern crate sha1;
 #[cfg(all(test, feature = "nightly"))]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -8,7 +8,7 @@ pub(crate) use self::fmt::fmt;
 pub(crate) use self::http_date::HttpDate;
 pub(crate) use self::iter::IterExt;
 //pub use language_tags::LanguageTag;
-//pub use self::quality_value::{Quality, QualityValue};
+pub(crate) use self::quality_value::QualityValue;
 pub(crate) use self::seconds::Seconds;
 pub(crate) use self::value_string::HeaderValueString;
 
@@ -20,7 +20,7 @@ mod flat_csv;
 mod fmt;
 mod http_date;
 mod iter;
-//mod quality_value;
+mod quality_value;
 mod seconds;
 mod value_string;
 

--- a/src/util/quality_value.rs
+++ b/src/util/quality_value.rs
@@ -6,6 +6,17 @@ use itertools::Itertools;
 use util::{FlatCsv, TryFromValues};
 use HeaderValue;
 
+/// A CSV list that respects the Quality Values syntax defined in
+/// [RFC7321](https://tools.ietf.org/html/rfc7231#section-5.3.1)
+/// 
+/// Many of the request header fields for proactive negotiation use a
+/// common parameter, named "q" (case-insensitive), to assign a relative
+/// "weight" to the preference for that associated kind of content.  This
+/// weight is referred to as a "quality value" (or "qvalue") because the
+/// same parameter name is often used within server configurations to
+/// assign a weight to the relative quality of the various
+/// representations that can be selected for a resource.
+/// 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct QualityValue<QualSep = SemiQ> {
     csv: FlatCsv,

--- a/src/util/quality_value.rs
+++ b/src/util/quality_value.rs
@@ -1,0 +1,175 @@
+use std::cmp::Ordering;
+use std::convert::TryFrom;
+use std::marker::PhantomData;
+
+use HeaderValue;
+use itertools::Itertools;
+use util::{FlatCsv, TryFromValues};
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct QualityValue<QualSep = SemiQ> {
+    csv: FlatCsv,
+    _marker: PhantomData<QualSep>,
+}
+
+pub(crate) trait QualityDelimiter {
+    const STR: &'static str;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) enum SemiQ {}
+
+impl QualityDelimiter for SemiQ {
+    const STR: &'static str = ";q=";
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct QualityMeta<'a, Sep = SemiQ> {
+    pub data: &'a str,
+    pub quality: u16,
+    _marker: PhantomData<Sep>,
+}
+
+impl<Delm: QualityDelimiter + Ord> Ord for QualityMeta<'_, Delm> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.quality.cmp(&self.quality)
+    }
+}
+
+impl<Delm: QualityDelimiter + Ord> PartialOrd for QualityMeta<'_, Delm> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<'a, Delm: QualityDelimiter> TryFrom<&'a str> for QualityMeta<'a, Delm> {
+    type Error = ::Error;
+
+    fn try_from(val: &'a str) -> Result<Self, ::Error> {
+        let mut parts: Vec<&str> = val.split(Delm::STR).collect();
+
+        match (parts.pop(), parts.pop()) {
+            (Some(qual), Some(data)) => {
+                let parsed: f32 = qual.parse().map_err(|_| ::Error::invalid())?;
+                let quality = (parsed * 1000_f32) as u16;
+
+                Ok(QualityMeta {
+                    data,
+                    quality,
+                    _marker: PhantomData,
+                })
+            }
+            // No deliter present, assign a quality value of 1
+            (Some(data), None) => Ok(QualityMeta {
+                data,
+                quality: 1000_u16,
+                _marker: PhantomData,
+            }),
+            _ => Err(::Error::invalid()),
+        }
+    }
+}
+
+impl<Delm: QualityDelimiter + Ord> QualityValue<Delm> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &str> {
+        self.csv
+            .iter()
+            .map(|v| QualityMeta::<Delm>::try_from(v).unwrap())
+            .into_iter()
+            .sorted()
+            .map(|pair| pair.data)
+            .into_iter()
+    }
+}
+
+impl<Delm: QualityDelimiter> From<FlatCsv> for QualityValue<Delm> {
+    fn from(csv: FlatCsv) -> Self {
+        QualityValue {
+            csv,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<Delm> From<HeaderValue> for QualityValue<Delm> {
+    fn from(value: HeaderValue) -> Self {
+        QualityValue {
+            csv: value.into(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, Delm> From<&'a QualityValue<Delm>> for HeaderValue {
+    fn from(qual: &'a QualityValue<Delm>) -> HeaderValue {
+        qual.csv.value.clone()
+    }
+}
+
+impl<Delm: QualityDelimiter> TryFromValues for QualityValue<Delm> {
+    fn try_from_values<'i, I>(values: &mut I) -> Result<Self, ::Error>
+    where 
+        I: Iterator<Item = &'i HeaderValue>,
+    {
+        let flat: FlatCsv = values.collect();
+        Ok(QualityValue::from(flat))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use util::flat_csv::Comma;
+    use HeaderValue;
+
+    #[test]
+    fn multiple_qualities() {
+        let val = HeaderValue::from_static("gzip;q=1, br;q=0.8");
+        let csv = FlatCsv::<Comma>::from(val);
+        let qual = QualityValue::<SemiQ>::from(csv);
+
+        let mut values = qual.iter();
+        assert_eq!(values.next(), Some("gzip"));
+        assert_eq!(values.next(), Some("br"));
+        assert_eq!(values.next(), None);
+    }
+
+    #[test]
+    fn multiple_qualities_wrong_order() {
+        let val = HeaderValue::from_static("br;q=0.8, gzip;q=1");
+        let csv = FlatCsv::<Comma>::from(val);
+        let qual = QualityValue::<SemiQ>::from(csv);
+
+        let mut values = qual.iter();
+        assert_eq!(values.next(), Some("gzip"));
+        assert_eq!(values.next(), Some("br"));
+        assert_eq!(values.next(), None);
+    }
+
+    #[test]
+    fn multiple_values() {
+        let val = HeaderValue::from_static("deflate, gzip;q=1, br;q=0.8");
+        let csv = FlatCsv::<Comma>::from(val);
+        let qual = QualityValue::<SemiQ>::from(csv);
+
+        let mut values = qual.iter();
+        assert_eq!(values.next(), Some("deflate"));
+        assert_eq!(values.next(), Some("gzip"));
+        assert_eq!(values.next(), Some("br"));
+        assert_eq!(values.next(), None);
+    }
+
+    #[test]
+    fn multiple_values_wrong_order() {
+        let val = HeaderValue::from_static("deflate, br;q=0.8, gzip;q=1, *;q=0.1");
+        let csv = FlatCsv::<Comma>::from(val);
+        let qual = QualityValue::<SemiQ>::from(csv);
+
+        let mut values = qual.iter();
+        assert_eq!(values.next(), Some("deflate"));
+        assert_eq!(values.next(), Some("gzip"));
+        assert_eq!(values.next(), Some("br"));
+        assert_eq!(values.next(), Some("*"));
+        assert_eq!(values.next(), None);
+    }
+}

--- a/src/util/quality_value.rs
+++ b/src/util/quality_value.rs
@@ -1,14 +1,10 @@
-use std::cmp::Ordering;
-use std::convert::{From, TryFrom};
+use self::sealed::SemiQ;
 use std::marker::PhantomData;
-
-use itertools::Itertools;
-use util::{FlatCsv, TryFromValues};
-use HeaderValue;
+use util::FlatCsv;
 
 /// A CSV list that respects the Quality Values syntax defined in
 /// [RFC7321](https://tools.ietf.org/html/rfc7231#section-5.3.1)
-/// 
+///
 /// Many of the request header fields for proactive negotiation use a
 /// common parameter, named "q" (case-insensitive), to assign a relative
 /// "weight" to the preference for that associated kind of content.  This
@@ -16,148 +12,162 @@ use HeaderValue;
 /// same parameter name is often used within server configurations to
 /// assign a weight to the relative quality of the various
 /// representations that can be selected for a resource.
-/// 
+///
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub(crate) struct QualityValue<QualSep = SemiQ> {
+pub struct QualityValue<QualSep = SemiQ> {
     csv: FlatCsv,
     _marker: PhantomData<QualSep>,
 }
 
-pub(crate) trait QualityDelimiter {
-    const STR: &'static str;
-}
+mod sealed {
+    use super::QualityValue;
+    use std::cmp::Ordering;
+    use std::convert::{From, TryFrom};
+    use std::marker::PhantomData;
 
-/// enum that represents the ';q=' delimiter
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub(crate) enum SemiQ {}
+    use itertools::Itertools;
+    use util::{FlatCsv, TryFromValues};
+    use HeaderValue;
 
-impl QualityDelimiter for SemiQ {
-    const STR: &'static str = ";q=";
-}
-
-/// enum that represents the ';level=' delimiter (extremely rare)
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub(crate) enum SemiLevel {}
-
-impl QualityDelimiter for SemiLevel {
-    const STR: &'static str = ";level=";
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct QualityMeta<'a, Sep = SemiQ> {
-    pub data: &'a str,
-    pub quality: u16,
-    _marker: PhantomData<Sep>,
-}
-
-impl<Delm: QualityDelimiter + Ord> Ord for QualityMeta<'_, Delm> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        other.quality.cmp(&self.quality)
+    pub trait QualityDelimiter {
+        const STR: &'static str;
     }
-}
 
-impl<Delm: QualityDelimiter + Ord> PartialOrd for QualityMeta<'_, Delm> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
+    /// enum that represents the ';q=' delimiter
+    #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+    pub enum SemiQ {}
+
+    impl QualityDelimiter for SemiQ {
+        const STR: &'static str = ";q=";
     }
-}
 
-impl<'a, Delm: QualityDelimiter> TryFrom<&'a str> for QualityMeta<'a, Delm> {
-    type Error = ::Error;
+    /// enum that represents the ';level=' delimiter (extremely rare)
+    #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+    pub enum SemiLevel {}
 
-    fn try_from(val: &'a str) -> Result<Self, ::Error> {
-        let mut parts: Vec<&str> = val.split(Delm::STR).collect();
+    impl QualityDelimiter for SemiLevel {
+        const STR: &'static str = ";level=";
+    }
 
-        match (parts.pop(), parts.pop()) {
-            (Some(qual), Some(data)) => {
-                let parsed: f32 = qual.parse().map_err(|_| ::Error::invalid())?;
-                let quality = (parsed * 1000_f32) as u16;
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct QualityMeta<'a, Sep = SemiQ> {
+        pub data: &'a str,
+        pub quality: u16,
+        _marker: PhantomData<Sep>,
+    }
 
-                Ok(QualityMeta {
+    impl<Delm: QualityDelimiter + Ord> Ord for QualityMeta<'_, Delm> {
+        fn cmp(&self, other: &Self) -> Ordering {
+            other.quality.cmp(&self.quality)
+        }
+    }
+
+    impl<Delm: QualityDelimiter + Ord> PartialOrd for QualityMeta<'_, Delm> {
+        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
+    impl<'a, Delm: QualityDelimiter> TryFrom<&'a str> for QualityMeta<'a, Delm> {
+        type Error = ::Error;
+
+        fn try_from(val: &'a str) -> Result<Self, ::Error> {
+            let mut parts: Vec<&str> = val.split(Delm::STR).collect();
+
+            match (parts.pop(), parts.pop()) {
+                (Some(qual), Some(data)) => {
+                    let parsed: f32 = qual.parse().map_err(|_| ::Error::invalid())?;
+                    let quality = (parsed * 1000_f32) as u16;
+
+                    Ok(QualityMeta {
+                        data,
+                        quality,
+                        _marker: PhantomData,
+                    })
+                }
+                // No deliter present, assign a quality value of 1
+                (Some(data), None) => Ok(QualityMeta {
                     data,
-                    quality,
+                    quality: 1000_u16,
                     _marker: PhantomData,
-                })
+                }),
+                _ => Err(::Error::invalid()),
             }
-            // No deliter present, assign a quality value of 1
-            (Some(data), None) => Ok(QualityMeta {
-                data,
-                quality: 1000_u16,
+        }
+    }
+
+    impl<Delm: QualityDelimiter + Ord> QualityValue<Delm> {
+        pub(crate) fn iter(&self) -> impl Iterator<Item = &str> {
+            self.csv
+                .iter()
+                .map(|v| QualityMeta::<Delm>::try_from(v).unwrap())
+                .into_iter()
+                .sorted()
+                .map(|pair| pair.data)
+                .into_iter()
+        }
+    }
+
+    impl<Delm: QualityDelimiter> From<FlatCsv> for QualityValue<Delm> {
+        fn from(csv: FlatCsv) -> Self {
+            QualityValue {
+                csv,
                 _marker: PhantomData,
-            }),
-            _ => Err(::Error::invalid()),
+            }
         }
     }
-}
 
-impl<Delm: QualityDelimiter + Ord> QualityValue<Delm> {
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &str> {
-        self.csv
-            .iter()
-            .map(|v| QualityMeta::<Delm>::try_from(v).unwrap())
-            .into_iter()
-            .sorted()
-            .map(|pair| pair.data)
-            .into_iter()
-    }
-}
+    impl<Delm: QualityDelimiter, F: Into<f32>> TryFrom<(&str, F)> for QualityValue<Delm> {
+        type Error = ::Error;
 
-impl<Delm: QualityDelimiter> From<FlatCsv> for QualityValue<Delm> {
-    fn from(csv: FlatCsv) -> Self {
-        QualityValue {
-            csv,
-            _marker: PhantomData,
+        fn try_from(pair: (&str, F)) -> Result<Self, ::Error> {
+            let value = HeaderValue::try_from(format!("{}{}{}", pair.0, Delm::STR, pair.1.into()))
+                .map_err(|_e| ::Error::invalid())?;
+            Ok(QualityValue {
+                csv: value.into(),
+                _marker: PhantomData,
+            })
         }
     }
-}
 
-impl<Delm: QualityDelimiter, F: Into<f32>> TryFrom<(&str, F)> for QualityValue<Delm> {
-    type Error = ::Error;
-
-    fn try_from(pair: (&str, F)) -> Result<Self, ::Error> {
-        let value = HeaderValue::try_from(format!("{}{}{}", pair.0, Delm::STR, pair.1.into()))
-            .map_err(|_e| ::Error::invalid())?;
-        Ok(QualityValue {
-            csv: value.into(),
-            _marker: PhantomData,
-        })
-    }
-}
-
-impl<Delm> From<HeaderValue> for QualityValue<Delm> {
-    fn from(value: HeaderValue) -> Self {
-        QualityValue {
-            csv: value.into(),
-            _marker: PhantomData,
+    impl<Delm> From<HeaderValue> for QualityValue<Delm> {
+        fn from(value: HeaderValue) -> Self {
+            QualityValue {
+                csv: value.into(),
+                _marker: PhantomData,
+            }
         }
     }
-}
 
-impl<'a, Delm> From<&'a QualityValue<Delm>> for HeaderValue {
-    fn from(qual: &'a QualityValue<Delm>) -> HeaderValue {
-        qual.csv.value.clone()
+    impl<'a, Delm> From<&'a QualityValue<Delm>> for HeaderValue {
+        fn from(qual: &'a QualityValue<Delm>) -> HeaderValue {
+            qual.csv.value.clone()
+        }
     }
-}
 
-impl<Delm> From<QualityValue<Delm>> for HeaderValue {
-    fn from(qual: QualityValue<Delm>) -> HeaderValue {
-        qual.csv.value
+    impl<Delm> From<QualityValue<Delm>> for HeaderValue {
+        fn from(qual: QualityValue<Delm>) -> HeaderValue {
+            qual.csv.value
+        }
     }
-}
 
-impl<Delm: QualityDelimiter> TryFromValues for QualityValue<Delm> {
-    fn try_from_values<'i, I>(values: &mut I) -> Result<Self, ::Error>
-    where
-        I: Iterator<Item = &'i HeaderValue>,
-    {
-        let flat: FlatCsv = values.collect();
-        Ok(QualityValue::from(flat))
+    impl<Delm: QualityDelimiter> TryFromValues for QualityValue<Delm> {
+        fn try_from_values<'i, I>(values: &mut I) -> Result<Self, ::Error>
+        where
+            I: Iterator<Item = &'i HeaderValue>,
+        {
+            let flat: FlatCsv = values.collect();
+            Ok(QualityValue::from(flat))
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{
+        sealed::{SemiLevel, SemiQ},
+        QualityValue,
+    };
     use HeaderValue;
 
     #[test]


### PR DESCRIPTION
This PR creates (re-adds?) an `AcceptEncoding` header which is built on top of a new struct `QualityValue`.

`QualityValue` is a wrapper around `FlatCsv` that parses the values in the csv as if they might have a quality value delimited by a default `";q="`. We adhere to the spec for quality value, namely, if a value in the header doesn't have a weighting, we assign a default value of 1, and then sort equal values by order in the header (test cases are included that assert this).

Motivation for this is to add an [auto compression filter](https://github.com/seanmonstar/warp/pull/472#issuecomment-596827732) to [warp](https://github.com/seanmonstar/warp).