### PR TITLE
Escape [sic] in docs (not an intra doc link)

### DIFF
--- a/src/common/referer.rs
+++ b/src/common/referer.rs
@@ -5,7 +5,7 @@ use http::header::HeaderValue;
 /// `Referer` header, defined in
 /// [RFC7231](http://tools.ietf.org/html/rfc7231#section-5.5.2)
 ///
-/// The `Referer` [sic] header field allows the user agent to specify a
+/// The `Referer` \[sic\] header field allows the user agent to specify a
 /// URI reference for the resource from which the target URI was obtained
 /// (i.e., the "referrer", though the field name is misspelled).  A user
 /// agent MUST NOT include the fragment and userinfo components of the


### PR DESCRIPTION
Fixes this warning:
```
warning: unresolved link to `sic`
 --> src/common/referer.rs:8:20
  |
8 | /// The `Referer` [sic] header field allows the user agent to specify a
  |                    ^^^ no item named `sic` in scope
  |
  = note: `#[warn(broken_intra_doc_links)]` on by default
  = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
```