### PR TITLE
feat: Provide a way to treat the cookie as bytes

### DIFF
--- a/src/util/flat_csv.rs
+++ b/src/util/flat_csv.rs
@@ -3,7 +3,7 @@ use std::iter::FromIterator;
 use std::marker::PhantomData;
 
 use bytes::BytesMut;
-use util::TryFromValues;
+use util::{trim_bytes, TryFromValues};
 use HeaderValue;
 
 // A single `HeaderValue` that can flatten multiple values with commas.
@@ -58,6 +58,30 @@ impl<Sep: Separator> FlatCsv<Sep> {
                 })
                 .map(|item| item.trim())
         })
+    }
+
+    pub(crate) fn iter_bytes(&self) -> impl Iterator<Item = &[u8]> {
+        let mut in_quotes = false;
+        self.value
+            .as_bytes()
+            .split(move |&c| {
+                if in_quotes {
+                    if c == b'"' {
+                        in_quotes = false;
+                    }
+                    false // dont split
+                } else {
+                    if c == Sep::BYTE {
+                        true // split
+                    } else {
+                        if c == b'"' {
+                            in_quotes = true;
+                        }
+                        false // dont split
+                    }
+                }
+            })
+            .map(trim_bytes)
     }
 }
 
@@ -120,8 +144,8 @@ impl<'a, Sep: Separator> FromIterator<&'a HeaderValue> for FlatCsv<Sep> {
             buf.extend_from_slice(val.as_bytes());
         }
 
-        let val =
-            HeaderValue::from_maybe_shared(buf.freeze()).expect("comma separated HeaderValues are valid");
+        let val = HeaderValue::from_maybe_shared(buf.freeze())
+            .expect("comma separated HeaderValues are valid");
 
         val.into()
     }
@@ -151,8 +175,8 @@ impl<Sep: Separator> FromIterator<HeaderValue> for FlatCsv<Sep> {
             buf.extend_from_slice(val.as_bytes());
         }
 
-        let val =
-            HeaderValue::from_maybe_shared(buf.freeze()).expect("comma separated HeaderValues are valid");
+        let val = HeaderValue::from_maybe_shared(buf.freeze())
+            .expect("comma separated HeaderValues are valid");
 
         val.into()
     }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -85,3 +85,30 @@ impl TryFromValues for HeaderValue {
         values.next().cloned().ok_or_else(|| ::Error::invalid())
     }
 }
+
+pub(crate) fn trim_bytes(mut b: &[u8]) -> &[u8] {
+    let start = b
+        .iter()
+        .position(|&b| !b.is_ascii_whitespace())
+        .unwrap_or_else(|| b.len());
+    b = &b[start..];
+    let end = b
+        .iter()
+        .rposition(|&b| !b.is_ascii_whitespace())
+        .map_or_else(|| b.len(), |i| i + 1);
+    &b[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trim_test() {
+        assert_eq!(trim_bytes(b"  123  "), b"123");
+        assert_eq!(trim_bytes(b"123  "), b"123");
+        assert_eq!(trim_bytes(b"  123"), b"123");
+        assert_eq!(trim_bytes(b"123"), b"123");
+        assert_eq!(trim_bytes(b"   "), b"");
+    }
+}


### PR DESCRIPTION
In some instances there can be an unrelated, invalid cookie which
prevents any cookies from being accessed as `HeaderValue::to_str`
returns `None` due to non-ascii characters. By providing a way to access
the cookie string as bytes there is an escape hatch to workaround this.