### PR TITLE
add TryFrom for AccessControlAllowOrigin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 env:
-  minrust: 1.41.0
+  minrust: 1.46.0
 
 jobs:
   test:


### PR DESCRIPTION
There is currently no way to build an `AccessControlAllowOrigin` with an actual origin value that isn't `Any` or `Null`. This PR adds a TryFrom trait to that header to fix this.

I added a line in the doctest and an additional test to cover this new trait.

~~It's a bit of an ugly implementation, because the only way to build an `OriginOrAny` at present is to `try_from_values` with an iterator.~~