### PR TITLE
make Range headers strongly typed (again)

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -52,6 +52,8 @@ pub use self::pragma::Pragma;
 //pub use self::prefer::{Prefer, Preference};
 //pub use self::preference_applied::PreferenceApplied;
 pub use self::proxy_authorization::ProxyAuthorization;
+pub use self::range::ByteRangeBuilder;
+pub use self::range::ByteRangeSpec;
 pub use self::range::Range;
 pub use self::referer::Referer;
 pub use self::referrer_policy::ReferrerPolicy;


### PR DESCRIPTION
fixes #87

<del>I'm very much not happy with it as it is right now, but this is what I've been able to hack together so far. I'm still posting it as a starting point for further work on this, and to be able to point out the points I'm unsure of.</del>

Current state of the PR: https://github.com/hyperium/headers/pull/93#pullrequestreview-782268136