### PR TITLE
Implement `From<Host>` for `Authority`

### DIFF
--- a/src/common/host.rs
+++ b/src/common/host.rs
@@ -47,6 +47,12 @@ impl From<Authority> for Host {
     }
 }
 
+impl From<Host> for Authority {
+    fn from(host: Host) -> Authority {
+        host.0
+    }
+}
+
 impl fmt::Display for Host {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)


### PR DESCRIPTION
The converse conversion exists, so unless `Host` is going to be able to contain something other than an authority in the future (unlikely) we can implement this conversion as well.