### PR TITLE
refactor: split the `Header` trait into three traits

### DIFF
--- a/headers-core/src/lib.rs
+++ b/headers-core/src/lib.rs
@@ -15,10 +15,36 @@ pub use http::header::{self, HeaderName, HeaderValue};
 use std::error;
 use std::fmt::{self, Display, Formatter};
 
+/// Associates a header name with a Rust type.
+pub trait Named {
+    /// The name of this header.
+    fn name() -> &'static HeaderName;
+}
+
+/// Decodes a header into a Rust type.
+pub trait Decodable: Named {
+    /// Decode this type from an iterator of `HeaderValue`s.
+    fn decode<'i, I>(values: &mut I) -> Result<Self, Error>
+    where
+        Self: Sized,
+        I: Iterator<Item = &'i HeaderValue>;
+}
+
+/// Encodes a header into a Rust type.
+pub trait Encodable: Named {
+    /// Encode this type to a `HeaderMap`.
+    ///
+    /// This function should be infallible. Any errors converting to a
+    /// `HeaderValue` should have been caught when parsing or constructing
+    /// this value.
+    fn encode<E: Extend<HeaderValue>>(&self, values: &mut E);
+}
+
 /// A trait for any object that will represent a header field and value.
 ///
 /// This trait represents the construction and identification of headers,
 /// and contains trait-object unsafe methods.
+#[deprecated]
 pub trait Header {
     /// The name of this header.
     fn name() -> &'static HeaderName;
@@ -35,6 +61,31 @@ pub trait Header {
     /// `HeaderValue` should have been caught when parsing or constructing
     /// this value.
     fn encode<E: Extend<HeaderValue>>(&self, values: &mut E);
+}
+
+#[allow(deprecated)]
+impl<T: Header> Named for T {
+    fn name() -> &'static HeaderName {
+        T::name()
+    }
+}
+
+#[allow(deprecated)]
+impl<T: Header> Decodable for T {
+    fn decode<'i, I>(values: &mut I) -> Result<Self, Error>
+    where
+        Self: Sized,
+        I: Iterator<Item = &'i HeaderValue>,
+    {
+        T::decode(values)
+    }
+}
+
+#[allow(deprecated)]
+impl<T: Header> Encodable for T {
+    fn encode<E: Extend<HeaderValue>>(&self, values: &mut E) {
+        self.encode(values)
+    }
 }
 
 /// Errors trying to decode a header.

--- a/src/common/access_control_allow_credentials.rs
+++ b/src/common/access_control_allow_credentials.rs
@@ -1,4 +1,5 @@
-use {Header, HeaderName, HeaderValue};
+use crate::core::{Decodable, Encodable, Named};
+use crate::{HeaderName, HeaderValue};
 
 /// `Access-Control-Allow-Credentials` header, part of
 /// [CORS](http://www.w3.org/TR/cors/#access-control-allow-headers-response-header)
@@ -33,11 +34,13 @@ use {Header, HeaderName, HeaderValue};
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct AccessControlAllowCredentials;
 
-impl Header for AccessControlAllowCredentials {
+impl Named for AccessControlAllowCredentials {
     fn name() -> &'static HeaderName {
         &::http::header::ACCESS_CONTROL_ALLOW_CREDENTIALS
     }
+}
 
+impl Decodable for AccessControlAllowCredentials {
     fn decode<'i, I: Iterator<Item = &'i HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values
             .next()
@@ -50,7 +53,9 @@ impl Header for AccessControlAllowCredentials {
             })
             .ok_or_else(::Error::invalid)
     }
+}
 
+impl Encodable for AccessControlAllowCredentials {
     fn encode<E: Extend<::HeaderValue>>(&self, values: &mut E) {
         values.extend(::std::iter::once(HeaderValue::from_static("true")));
     }

--- a/src/common/access_control_request_method.rs
+++ b/src/common/access_control_request_method.rs
@@ -1,5 +1,7 @@
+use crate::core::{Decodable, Encodable, Named};
+use crate::{HeaderName, HeaderValue};
+
 use http::Method;
-use {Header, HeaderName, HeaderValue};
 
 /// `Access-Control-Request-Method` header, part of
 /// [CORS](http://www.w3.org/TR/cors/#access-control-request-method-request-header)
@@ -28,11 +30,13 @@ use {Header, HeaderName, HeaderValue};
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct AccessControlRequestMethod(Method);
 
-impl Header for AccessControlRequestMethod {
+impl Named for AccessControlRequestMethod {
     fn name() -> &'static HeaderName {
         &::http::header::ACCESS_CONTROL_REQUEST_METHOD
     }
+}
 
+impl Decodable for AccessControlRequestMethod {
     fn decode<'i, I: Iterator<Item = &'i HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values
             .next()
@@ -40,7 +44,9 @@ impl Header for AccessControlRequestMethod {
             .map(AccessControlRequestMethod)
             .ok_or_else(::Error::invalid)
     }
+}
 
+impl Encodable for AccessControlRequestMethod {
     fn encode<E: Extend<::HeaderValue>>(&self, values: &mut E) {
         // For the more common methods, try to use a static string.
         let s = match self.0 {

--- a/src/common/authorization.rs
+++ b/src/common/authorization.rs
@@ -1,5 +1,7 @@
 //! Authorization header and types.
 
+use crate::core::{Decodable, Encodable, Named};
+
 use base64;
 use bytes::Bytes;
 
@@ -71,11 +73,13 @@ impl Authorization<Bearer> {
     }
 }
 
-impl<C: Credentials> ::Header for Authorization<C> {
+impl<C: Credentials> Named for Authorization<C> {
     fn name() -> &'static ::HeaderName {
         &::http::header::AUTHORIZATION
     }
+}
 
+impl<C: Credentials> Decodable for Authorization<C> {
     fn decode<'i, I: Iterator<Item = &'i HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values
             .next()
@@ -92,7 +96,9 @@ impl<C: Credentials> ::Header for Authorization<C> {
             })
             .ok_or_else(::Error::invalid)
     }
+}
 
+impl<C: Credentials> Encodable for Authorization<C> {
     fn encode<E: Extend<::HeaderValue>>(&self, values: &mut E) {
         let value = self.0.encode();
         debug_assert!(
@@ -171,7 +177,8 @@ impl Credentials for Basic {
         base64::encode_config_buf(&self.decoded, base64::STANDARD, &mut encoded);
 
         let bytes = Bytes::from(encoded);
-        HeaderValue::from_maybe_shared(bytes).expect("base64 encoding is always a valid HeaderValue")
+        HeaderValue::from_maybe_shared(bytes)
+            .expect("base64 encoding is always a valid HeaderValue")
     }
 }
 

--- a/src/common/cache_control.rs
+++ b/src/common/cache_control.rs
@@ -3,6 +3,8 @@ use std::iter::FromIterator;
 use std::str::FromStr;
 use std::time::Duration;
 
+use crate::core::{Decodable, Encodable, Named};
+
 use util::{self, csv, Seconds};
 use HeaderValue;
 
@@ -183,15 +185,19 @@ impl CacheControl {
     }
 }
 
-impl ::Header for CacheControl {
+impl Named for CacheControl {
     fn name() -> &'static ::HeaderName {
         &::http::header::CACHE_CONTROL
     }
+}
 
+impl Decodable for CacheControl {
     fn decode<'i, I: Iterator<Item = &'i HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         csv::from_comma_delimited(values).map(|FromIter(cc)| cc)
     }
+}
 
+impl Encodable for CacheControl {
     fn encode<E: Extend<::HeaderValue>>(&self, values: &mut E) {
         values.extend(::std::iter::once(util::fmt(Fmt(self))));
     }

--- a/src/common/content_disposition.rs
+++ b/src/common/content_disposition.rs
@@ -6,6 +6,8 @@
 // Browser conformance tests at: http://greenbytes.de/tech/tc2231/
 // IANA assignment: http://www.iana.org/assignments/cont-disp/cont-disp.xhtml
 
+use crate::core::{Decodable, Encodable, Named};
+
 /// A `Content-Disposition` header, (re)defined in [RFC6266](https://tools.ietf.org/html/rfc6266).
 ///
 /// The Content-Disposition response header field is used to convey
@@ -89,11 +91,13 @@ impl ContentDisposition {
     }
 }
 
-impl ::Header for ContentDisposition {
+impl Named for ContentDisposition {
     fn name() -> &'static ::HeaderName {
         &::http::header::CONTENT_DISPOSITION
     }
+}
 
+impl Decodable for ContentDisposition {
     fn decode<'i, I: Iterator<Item = &'i ::HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         //TODO: parse harder
         values
@@ -102,7 +106,9 @@ impl ::Header for ContentDisposition {
             .map(ContentDisposition)
             .ok_or_else(::Error::invalid)
     }
+}
 
+impl Encodable for ContentDisposition {
     fn encode<E: Extend<::HeaderValue>>(&self, values: &mut E) {
         values.extend(::std::iter::once(self.0.clone()));
     }

--- a/src/common/content_length.rs
+++ b/src/common/content_length.rs
@@ -1,4 +1,5 @@
-use {Header, HeaderValue};
+use crate::core::{Decodable, Encodable, Named};
+use crate::HeaderValue;
 
 /// `Content-Length` header, defined in
 /// [RFC7230](http://tools.ietf.org/html/rfc7230#section-3.3.2)
@@ -40,11 +41,13 @@ use {Header, HeaderValue};
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ContentLength(pub u64);
 
-impl Header for ContentLength {
+impl Named for ContentLength {
     fn name() -> &'static ::http::header::HeaderName {
         &::http::header::CONTENT_LENGTH
     }
+}
 
+impl Decodable for ContentLength {
     fn decode<'i, I: Iterator<Item = &'i HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         // If multiple Content-Length headers were sent, everything can still
         // be alright if they all contain the same value, and all parse
@@ -68,7 +71,9 @@ impl Header for ContentLength {
 
         len.map(ContentLength).ok_or_else(::Error::invalid)
     }
+}
 
+impl Encodable for ContentLength {
     fn encode<E: Extend<::HeaderValue>>(&self, values: &mut E) {
         values.extend(::std::iter::once(self.0.into()));
     }

--- a/src/common/content_range.rs
+++ b/src/common/content_range.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 use std::ops::{Bound, RangeBounds};
 
-use {util, HeaderValue};
+use crate::core::{Decodable, Encodable, Named};
+use crate::{util, HeaderValue};
 
 /// Content-Range, described in [RFC7233](https://tools.ietf.org/html/rfc7233#section-4.2)
 ///
@@ -98,11 +99,13 @@ impl ContentRange {
     }
 }
 
-impl ::Header for ContentRange {
+impl Named for ContentRange {
     fn name() -> &'static ::HeaderName {
         &::http::header::CONTENT_RANGE
     }
+}
 
+impl Decodable for ContentRange {
     fn decode<'i, I: Iterator<Item = &'i HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values
             .next()
@@ -141,7 +144,9 @@ impl ::Header for ContentRange {
             })
             .ok_or_else(::Error::invalid)
     }
+}
 
+impl Encodable for ContentRange {
     fn encode<E: Extend<::HeaderValue>>(&self, values: &mut E) {
         struct Adapter<'a>(&'a ContentRange);
 
@@ -178,22 +183,23 @@ fn split_in_two(s: &str, separator: char) -> Option<(&str, &str)> {
 }
 
 /*
-        test_header!(test_bytes,
-            vec![b"bytes 0-499/500"],
-            Some(ContentRange(ContentRangeSpec::Bytes {
-                range: Some((0, 499)),
-                complete_length: Some(500)
-            })));
+test_header!(test_bytes,
+    vec![b"bytes 0-499/500"],
+    Some(ContentRange(ContentRangeSpec::Bytes {
+        range: Some((0, 499)),
+        complete_length: Some(500)
+    })));
 
-        test_header!(test_bytes_unknown_len,
-            vec![b"bytes 0-499/*"],
-            Some(ContentRange(ContentRangeSpec::Bytes {
-                range: Some((0, 499)),
-                complete_length: None
-            })));
+test_header!(test_bytes_unknown_len,
+    vec![b"bytes 0-499/*"],
+    Some(ContentRange(ContentRangeSpec::Bytes {
+        range: Some((0, 499)),
+        complete_length: None
+    })));
 
-        test_header!(test_bytes_unknown_range,
-            vec![b"bytes */500"],
+test_header!(test_bytes_unknown_range,
+    vec![b"bytes */
+500"],
             Some(ContentRange(ContentRangeSpec::Bytes {
                 range: None,
                 complete_length: Some(500)

--- a/src/common/content_type.rs
+++ b/src/common/content_type.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use crate::core::{Decodable, Encodable, Named};
+
 use mime::{self, Mime};
 
 /// `Content-Type` header, defined in
@@ -94,11 +96,13 @@ impl ContentType {
     }
 }
 
-impl ::Header for ContentType {
+impl Named for ContentType {
     fn name() -> &'static ::HeaderName {
         &::http::header::CONTENT_TYPE
     }
+}
 
+impl Decodable for ContentType {
     fn decode<'i, I: Iterator<Item = &'i ::HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values
             .next()
@@ -106,7 +110,9 @@ impl ::Header for ContentType {
             .map(ContentType)
             .ok_or_else(::Error::invalid)
     }
+}
 
+impl Encodable for ContentType {
     fn encode<E: Extend<::HeaderValue>>(&self, values: &mut E) {
         let value = self
             .0

--- a/src/common/expect.rs
+++ b/src/common/expect.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use crate::core::{Decodable, Encodable, Named};
+
 use util::IterExt;
 
 /// The `Expect` header.
@@ -27,11 +29,13 @@ impl Expect {
     pub const CONTINUE: Expect = Expect(());
 }
 
-impl ::Header for Expect {
+impl Named for Expect {
     fn name() -> &'static ::HeaderName {
         &::http::header::EXPECT
     }
+}
 
+impl Decodable for Expect {
     fn decode<'i, I: Iterator<Item = &'i ::HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values
             .just_one()
@@ -44,7 +48,9 @@ impl ::Header for Expect {
             })
             .ok_or_else(::Error::invalid)
     }
+}
 
+impl Encodable for Expect {
     fn encode<E: Extend<::HeaderValue>>(&self, values: &mut E) {
         values.extend(::std::iter::once(::HeaderValue::from_static(
             "100-continue",

--- a/src/common/host.rs
+++ b/src/common/host.rs
@@ -1,5 +1,7 @@
-use std::fmt;
 use std::convert::TryFrom;
+use std::fmt;
+
+use crate::core::{Decodable, Encodable, Named};
 
 use http::uri::Authority;
 
@@ -19,11 +21,13 @@ impl Host {
     }
 }
 
-impl ::Header for Host {
+impl Named for Host {
     fn name() -> &'static ::HeaderName {
         &::http::header::HOST
     }
+}
 
+impl Decodable for Host {
     fn decode<'i, I: Iterator<Item = &'i ::HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values
             .next()
@@ -32,7 +36,9 @@ impl ::Header for Host {
             .map(Host)
             .ok_or_else(::Error::invalid)
     }
+}
 
+impl Encodable for Host {
     fn encode<E: Extend<::HeaderValue>>(&self, values: &mut E) {
         let bytes = self.0.as_str().as_bytes();
         let val = ::HeaderValue::from_bytes(bytes).expect("Authority is a valid HeaderValue");

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -70,7 +70,7 @@ pub use self::vary::Vary;
 //pub use self::warning::Warning;
 
 #[cfg(test)]
-fn test_decode<T: ::Header>(values: &[&str]) -> Option<T> {
+fn test_decode<T: headers_core::Decodable>(values: &[&str]) -> Option<T> {
     use HeaderMapExt;
     let mut map = ::http::HeaderMap::new();
     for val in values {
@@ -80,7 +80,7 @@ fn test_decode<T: ::Header>(values: &[&str]) -> Option<T> {
 }
 
 #[cfg(test)]
-fn test_encode<T: ::Header>(header: T) -> ::http::HeaderMap {
+fn test_encode<T: headers_core::Encodable>(header: T) -> ::http::HeaderMap {
     use HeaderMapExt;
     let mut map = ::http::HeaderMap::new();
     map.typed_insert(header);

--- a/src/common/proxy_authorization.rs
+++ b/src/common/proxy_authorization.rs
@@ -1,4 +1,5 @@
 use super::authorization::{Authorization, Credentials};
+use crate::core::{Decodable, Encodable, Named};
 
 /// `Proxy-Authorization` header, defined in [RFC7235](https://tools.ietf.org/html/rfc7235#section-4.4)
 ///
@@ -24,15 +25,19 @@ use super::authorization::{Authorization, Credentials};
 #[derive(Clone, PartialEq, Debug)]
 pub struct ProxyAuthorization<C: Credentials>(pub C);
 
-impl<C: Credentials> ::Header for ProxyAuthorization<C> {
+impl<C: Credentials> Named for ProxyAuthorization<C> {
     fn name() -> &'static ::HeaderName {
         &::http::header::PROXY_AUTHORIZATION
     }
+}
 
+impl<C: Credentials> Decodable for ProxyAuthorization<C> {
     fn decode<'i, I: Iterator<Item = &'i ::HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         Authorization::decode(values).map(|auth| ProxyAuthorization(auth.0))
     }
+}
 
+impl<C: Credentials> Encodable for ProxyAuthorization<C> {
     fn encode<E: Extend<::HeaderValue>>(&self, values: &mut E) {
         let value = self.0.encode();
         debug_assert!(

--- a/src/common/range.rs
+++ b/src/common/range.rs
@@ -1,5 +1,7 @@
 use std::ops::{Bound, RangeBounds};
 
+use crate::core::{Decodable, Encodable, Named};
+
 /// `Range` header, defined in [RFC7233](https://tools.ietf.org/html/rfc7233#section-3.1)
 ///
 /// The "Range" header field on a GET request modifies the method
@@ -83,11 +85,13 @@ fn parse_bound(s: &str) -> Option<Bound<u64>> {
     s.parse().ok().map(Bound::Included)
 }
 
-impl ::Header for Range {
+impl Named for Range {
     fn name() -> &'static ::HeaderName {
         &::http::header::RANGE
     }
+}
 
+impl Decodable for Range {
     fn decode<'i, I: Iterator<Item = &'i ::HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values
             .next()
@@ -100,7 +104,9 @@ impl ::Header for Range {
             })
             .ok_or_else(::Error::invalid)
     }
+}
 
+impl Encodable for Range {
     fn encode<E: Extend<::HeaderValue>>(&self, values: &mut E) {
         values.extend(::std::iter::once(self.0.clone()));
     }

--- a/src/common/sec_websocket_version.rs
+++ b/src/common/sec_websocket_version.rs
@@ -1,3 +1,5 @@
+use crate::core::{Decodable, Encodable, Named};
+
 /// The `Sec-Websocket-Version` header.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct SecWebsocketVersion(u8);
@@ -7,11 +9,13 @@ impl SecWebsocketVersion {
     pub const V13: SecWebsocketVersion = SecWebsocketVersion(13);
 }
 
-impl ::Header for SecWebsocketVersion {
+impl Named for SecWebsocketVersion {
     fn name() -> &'static ::HeaderName {
         &::http::header::SEC_WEBSOCKET_VERSION
     }
+}
 
+impl Decodable for SecWebsocketVersion {
     fn decode<'i, I: Iterator<Item = &'i ::HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values
             .next()
@@ -24,7 +28,9 @@ impl ::Header for SecWebsocketVersion {
             })
             .ok_or_else(::Error::invalid)
     }
+}
 
+impl Encodable for SecWebsocketVersion {
     fn encode<E: Extend<::HeaderValue>>(&self, values: &mut E) {
         debug_assert_eq!(self.0, 13);
 

--- a/src/common/set_cookie.rs
+++ b/src/common/set_cookie.rs
@@ -1,3 +1,5 @@
+use crate::core::{Decodable, Encodable, Named};
+
 /// `Set-Cookie` header, defined [RFC6265](http://tools.ietf.org/html/rfc6265#section-4.1)
 ///
 /// The Set-Cookie HTTP response header is used to send cookies from the
@@ -54,11 +56,13 @@
 #[derive(Clone, Debug)]
 pub struct SetCookie(Vec<::HeaderValue>);
 
-impl ::Header for SetCookie {
+impl Named for SetCookie {
     fn name() -> &'static ::HeaderName {
         &::http::header::SET_COOKIE
     }
+}
 
+impl Decodable for SetCookie {
     fn decode<'i, I: Iterator<Item = &'i ::HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         let vec = values.cloned().collect::<Vec<_>>();
 
@@ -68,7 +72,9 @@ impl ::Header for SetCookie {
             Err(::Error::invalid())
         }
     }
+}
 
+impl Encodable for SetCookie {
     fn encode<E: Extend<::HeaderValue>>(&self, values: &mut E) {
         values.extend(self.0.iter().cloned());
     }

--- a/src/common/strict_transport_security.rs
+++ b/src/common/strict_transport_security.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 use std::time::Duration;
 
+use crate::core::{Decodable, Encodable, Named};
+
 use util::{self, IterExt, Seconds};
 
 /// `StrictTransportSecurity` header, defined in [RFC6797](https://tools.ietf.org/html/rfc6797)
@@ -129,11 +131,13 @@ fn from_str(s: &str) -> Result<StrictTransportSecurity, ::Error> {
         .ok_or_else(::Error::invalid)
 }
 
-impl ::Header for StrictTransportSecurity {
+impl Named for StrictTransportSecurity {
     fn name() -> &'static ::HeaderName {
         &::http::header::STRICT_TRANSPORT_SECURITY
     }
+}
 
+impl Decodable for StrictTransportSecurity {
     fn decode<'i, I: Iterator<Item = &'i ::HeaderValue>>(values: &mut I) -> Result<Self, ::Error> {
         values
             .just_one()
@@ -141,7 +145,9 @@ impl ::Header for StrictTransportSecurity {
             .map(from_str)
             .unwrap_or_else(|| Err(::Error::invalid()))
     }
+}
 
+impl Encodable for StrictTransportSecurity {
     fn encode<E: Extend<::HeaderValue>>(&self, values: &mut E) {
         struct Adapter<'a>(&'a StrictTransportSecurity);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! # Defining Custom Headers
 //!
-//! ## Implementing the `Header` trait
+//! ## Implementing the header traits
 //!
 //! Consider a Do Not Track header. It can be true or false, but it represents
 //! that via the numerals `1` and `0`.
@@ -29,15 +29,18 @@
 //! extern crate http;
 //! extern crate headers;
 //!
-//! use headers::{Header, HeaderName, HeaderValue};
+//! use headers::{HeaderName, HeaderValue};
+//! use headers::core::{Decodable, Encodable, Named};
 //!
 //! struct Dnt(bool);
 //!
-//! impl Header for Dnt {
+//! impl Named for Dnt {
 //!     fn name() -> &'static HeaderName {
 //!          &http::header::DNT
 //!     }
+//! }
 //!
+//! impl Decodable for Dnt {
 //!     fn decode<'i, I>(values: &mut I) -> Result<Self, headers::Error>
 //!     where
 //!         I: Iterator<Item = &'i HeaderValue>,
@@ -54,7 +57,9 @@
 //!             Err(headers::Error::invalid())
 //!         }
 //!     }
+//! }
 //!
+//! impl Encodable for Dnt {
 //!     fn encode<E>(&self, values: &mut E)
 //!     where
 //!         E: Extend<HeaderValue>,
@@ -76,7 +81,7 @@ extern crate base64;
 #[macro_use]
 extern crate bitflags;
 extern crate bytes;
-extern crate headers_core;
+pub extern crate headers_core;
 extern crate http;
 extern crate httpdate;
 extern crate mime;
@@ -84,6 +89,8 @@ extern crate sha1;
 #[cfg(all(test, feature = "nightly"))]
 extern crate test;
 
+pub use headers_core as core;
+#[allow(deprecated)]
 pub use headers_core::{Error, Header};
 
 #[doc(hidden)]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -49,18 +49,22 @@ macro_rules! error_type {
 
 macro_rules! derive_header {
     ($type:ident(_), name: $name:ident) => {
-        impl crate::Header for $type {
+        impl ::headers_core::Named for $type {
             fn name() -> &'static ::http::header::HeaderName {
                 &::http::header::$name
             }
+        }
 
+        impl ::headers_core::Decodable for $type {
             fn decode<'i, I>(values: &mut I) -> Result<Self, ::Error>
             where
                 I: Iterator<Item = &'i ::http::header::HeaderValue>,
             {
                 ::util::TryFromValues::try_from_values(values).map($type)
             }
+        }
 
+        impl ::headers_core::Encodable for $type {
             fn encode<E: Extend<::HeaderValue>>(&self, values: &mut E) {
                 values.extend(::std::iter::once((&self.0).into()));
             }


### PR DESCRIPTION
The `Header` trait is now `Named`, `Decodable` and `Encodable`.

The goal of this change is to make it possible to implement `Encodable`
for borrowed types. Under the existing code, `Header::decode()` requires
that `Self` own its data. But it is a legitimate use to do
`Header::encode()` on borrowed data. By separating the traits, we can
implement `Encodable` on borrowed types and `Encodable` and `Decodable`
on owned types.

Signed-off-by: Nathaniel McCallum <nathaniel@profian.com>