### PR TITLE
Add From<Origin> implementation for AccessControlAllowOrigin

### DIFF
--- a/src/common/access_control_allow_origin.rs
+++ b/src/common/access_control_allow_origin.rs
@@ -74,6 +74,12 @@ impl TryFrom<&str> for AccessControlAllowOrigin {
     }
 }
 
+impl From<Origin> for AccessControlAllowOrigin {
+    fn from(origin: Origin) -> Self {
+        Self(OriginOrAny::Origin(origin))
+    }
+}
+
 impl TryFrom<&HeaderValue> for OriginOrAny {
     type Error = ::Error;
 


### PR DESCRIPTION
Currently the `TryFrom<&str>` implementation is the only way – as far as I can tell – to create an `AccessControlAllowOrigin` header for a specific origin. If you already have an `Origin`, it feels a bit silly to use `TryFrom`, since the conversion should be simple and infallible. This change adds that conversion.