### PR TITLE
Switch from `sha-1` to `sha1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ base64 = "0.13"
 bitflags = "1.0"
 bytes = "1"
 mime = "0.3.14"
-sha-1 = "0.10"
+sha1 = "0.10"
 httpdate = "1"
 
 [features]


### PR DESCRIPTION
The RustCrypto project recently got control of the crate name `sha1`. This
commit switches over to the new name; the old `sha-1` name is now deprecated.

Details: https://github.com/RustCrypto/hashes/pull/350