### PR TITLE
Bump MSRV to 1.51

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 env:
-  minrust: 1.46.0
+  minrust: 1.51.0
 
 jobs:
   test:


### PR DESCRIPTION
Fixes the MSRV job by bumping to 1.51 as required by the `sha1` crate