### PR TITLE
Increment version to address sha-1 deprecation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headers"
-version = "0.3.7" # don't forget to update html_root_url
+version = "0.3.8" # don't forget to update html_root_url
 description = "typed HTTP headers"
 license = "MIT"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
-#![doc(html_root_url = "https://docs.rs/headers/0.3.7")]
+#![doc(html_root_url = "https://docs.rs/headers/0.3.8")]
 
 //! # Typed HTTP Headers
 //!


### PR DESCRIPTION
Closes #38 

Makes `sha-1`->`sha1` change (31fe3e19e5763b95c9b5dfed1569bef555380dc4) available without a git dependency.