### PR TITLE
Add a FromStr implementation for ContentType

### DIFF
--- a/src/common/content_type.rs
+++ b/src/common/content_type.rs
@@ -135,6 +135,14 @@ impl fmt::Display for ContentType {
     }
 }
 
+impl std::str::FromStr for ContentType {
+    type Err = mime::FromStrError;
+
+    fn from_str(s: &str) -> Result<ContentType, Self::Err> {
+        s.parse::<Mime>().map(|m| m.into())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::test_decode;
@@ -145,6 +153,14 @@ mod tests {
         assert_eq!(
             test_decode::<ContentType>(&["application/json"]),
             Some(ContentType::json()),
+        );
+    }
+
+    #[test]
+    fn from_str() {
+        assert_eq!(
+            "application/json".parse::<ContentType>().unwrap(),
+            ContentType::json()
         );
     }
 


### PR DESCRIPTION
Currently, you have to do a bit of a dance to convert it to a MIME and then to a ContentType. This is simpler! Some of the other headers have this functionality (eg ETag).

The implementation simply passes it through to the MIME underlying. Added a test as well.