### PR TITLE
Update to bitflags 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 http = "0.2.0"
 headers-core = { version = "0.2", path = "./headers-core" }
 base64 = "0.13"
-bitflags = "1.0"
+bitflags = "2.0.2"
 bytes = "1"
 mime = "0.3.14"
 sha1 = "0.10"

--- a/src/common/cache_control.rs
+++ b/src/common/cache_control.rs
@@ -45,6 +45,7 @@ pub struct CacheControl {
 }
 
 bitflags! {
+    #[derive(Debug, Clone, PartialEq)]
     struct Flags: u32 {
         const NO_CACHE         = 0b000000001;
         const NO_STORE         = 0b000000010;


### PR DESCRIPTION
Updates to [bitflags version 2](https://github.com/bitflags/bitflags/releases/tag/2.0.2).