### PR TITLE
Replace base64 crate with data-encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ members = [
 [dependencies]
 http = "0.2.0"
 headers-core = { version = "0.2", path = "./headers-core" }
-base64 = "0.13"
 bytes = "1"
+data-encoding = "2"
 mime = "0.3.14"
 sha1 = "0.10"
 httpdate = "1"

--- a/src/common/authorization.rs
+++ b/src/common/authorization.rs
@@ -1,7 +1,7 @@
 //! Authorization header and types.
 
-use base64;
 use bytes::Bytes;
+use data_encoding::BASE64;
 
 use util::HeaderValueString;
 use HeaderValue;
@@ -158,7 +158,7 @@ impl Credentials for Basic {
         let bytes = &value.as_bytes()["Basic ".len()..];
         let non_space_pos = bytes.iter().position(|b| *b != b' ')?;
         let bytes = &bytes[non_space_pos..];
-        let bytes = base64::decode(bytes).ok()?;
+        let bytes = BASE64.decode(bytes).ok()?;
 
         let decoded = String::from_utf8(bytes).ok()?;
 
@@ -169,7 +169,7 @@ impl Credentials for Basic {
 
     fn encode(&self) -> HeaderValue {
         let mut encoded = String::from("Basic ");
-        base64::encode_config_buf(&self.decoded, base64::STANDARD, &mut encoded);
+        BASE64.encode_append(self.decoded.as_bytes(), &mut encoded);
 
         let bytes = Bytes::from(encoded);
         HeaderValue::from_maybe_shared(bytes)

--- a/src/common/sec_websocket_accept.rs
+++ b/src/common/sec_websocket_accept.rs
@@ -1,5 +1,5 @@
-use base64;
 use bytes::Bytes;
+use data_encoding::BASE64;
 use sha1::{Digest, Sha1};
 
 use super::SecWebsocketKey;
@@ -39,7 +39,7 @@ fn sign(key: &[u8]) -> SecWebsocketAccept {
     let mut sha1 = Sha1::default();
     sha1.update(key);
     sha1.update(&b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"[..]);
-    let b64 = Bytes::from(base64::encode(&sha1.finalize()));
+    let b64 = Bytes::from(BASE64.encode(&sha1.finalize()));
 
     let val = ::HeaderValue::from_maybe_shared(b64).expect("base64 is a valid value");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,8 +72,8 @@
 //! }
 //! ```
 
-extern crate base64;
 extern crate bytes;
+extern crate data_encoding;
 extern crate headers_core;
 extern crate http;
 extern crate httpdate;


### PR DESCRIPTION
base64 crate has recently raised their MSRV to 1.60 with large changes in 0.21, tungstenite crate has opted to move to data-encoding crate, MSRV 1.47

data-encoding's API stays closer to base64 0.13 than revamped base64 0.21

https://github.com/snapview/tungstenite-rs/pull/330