### PR TITLE
Make authorization schemes case and whitespace insensitive

### DIFF
--- a/src/common/authorization.rs
+++ b/src/common/authorization.rs
@@ -81,9 +81,10 @@ impl<C: Credentials> ::Header for Authorization<C> {
             .next()
             .and_then(|val| {
                 let slice = val.as_bytes();
-                if slice.starts_with(C::SCHEME.as_bytes())
-                    && slice.len() > C::SCHEME.len()
+                if slice.len() > C::SCHEME.len()
                     && slice[C::SCHEME.len()] == b' '
+                    && slice[..C::SCHEME.len()].to_ascii_lowercase()
+                        == C::SCHEME.to_ascii_lowercase().as_bytes()
                 {
                     C::decode(val).map(Authorization)
                 } else {
@@ -150,7 +151,7 @@ impl Credentials for Basic {
 
     fn decode(value: &HeaderValue) -> Option<Self> {
         debug_assert!(
-            value.as_bytes().starts_with(b"Basic "),
+            value.as_bytes().to_ascii_lowercase().starts_with(b"basic "),
             "HeaderValue to decode should start with \"Basic ..\", received = {:?}",
             value,
         );
@@ -184,7 +185,7 @@ pub struct Bearer(HeaderValueString);
 impl Bearer {
     /// View the token part as a `&str`.
     pub fn token(&self) -> &str {
-        &self.0.as_str()["Bearer ".len()..]
+        self.0.as_str()["Bearer ".len()..].trim_start()
     }
 }
 
@@ -193,7 +194,10 @@ impl Credentials for Bearer {
 
     fn decode(value: &HeaderValue) -> Option<Self> {
         debug_assert!(
-            value.as_bytes().starts_with(b"Bearer "),
+            value
+                .as_bytes()
+                .to_ascii_lowercase()
+                .starts_with(b"bearer "),
             "HeaderValue to decode should start with \"Bearer ..\", received = {:?}",
             value,
         );
@@ -251,6 +255,22 @@ mod tests {
     }
 
     #[test]
+    fn basic_decode_case_insensitive() {
+        let auth: Authorization<Basic> =
+            test_decode(&["basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="]).unwrap();
+        assert_eq!(auth.0.username(), "Aladdin");
+        assert_eq!(auth.0.password(), "open sesame");
+    }
+
+    #[test]
+    fn basic_decode_extra_whitespaces() {
+        let auth: Authorization<Basic> =
+            test_decode(&["Basic  QWxhZGRpbjpvcGVuIHNlc2FtZQ=="]).unwrap();
+        assert_eq!(auth.0.username(), "Aladdin");
+        assert_eq!(auth.0.password(), "open sesame");
+    }
+
+    #[test]
     fn basic_decode_no_password() {
         let auth: Authorization<Basic> = test_decode(&["Basic QWxhZGRpbjo="]).unwrap();
         assert_eq!(auth.0.username(), "Aladdin");
@@ -269,6 +289,18 @@ mod tests {
     #[test]
     fn bearer_decode() {
         let auth: Authorization<Bearer> = test_decode(&["Bearer fpKL54jvWmEGVoRdCNjG"]).unwrap();
+        assert_eq!(auth.0.token().as_bytes(), b"fpKL54jvWmEGVoRdCNjG");
+    }
+
+    #[test]
+    fn bearer_decode_case_insensitive() {
+        let auth: Authorization<Bearer> = test_decode(&["bearer fpKL54jvWmEGVoRdCNjG"]).unwrap();
+        assert_eq!(auth.0.token().as_bytes(), b"fpKL54jvWmEGVoRdCNjG");
+    }
+
+    #[test]
+    fn bearer_decode_extra_whitespaces() {
+        let auth: Authorization<Bearer> = test_decode(&["Bearer   fpKL54jvWmEGVoRdCNjG"]).unwrap();
         assert_eq!(auth.0.token().as_bytes(), b"fpKL54jvWmEGVoRdCNjG");
     }
 }


### PR DESCRIPTION
Partially address #112, missing are restrictions on the shape of the actual Bearer token 