### PR TITLE
Add support for "must-understand" directive

### DIFF
--- a/src/common/cache_control.rs
+++ b/src/common/cache_control.rs
@@ -270,7 +270,7 @@ impl FromIterator<KnownDirective> for FromIter {
                 }
                 Directive::MustUnderstand => {
                     cc.flags.insert(Flags::MUST_UNDERSTAND);
-                 }
+                }
                 Directive::Public => {
                     cc.flags.insert(Flags::PUBLIC);
                 }
@@ -494,7 +494,10 @@ mod tests {
         let cc = CacheControl::new().with_must_understand();
         let headers = test_encode(cc.clone());
         assert_eq!(headers["cache-control"], "must-understand");
-        assert_eq!(test_decode::<CacheControl>(&["must-understand"]).unwrap(), cc);
+        assert_eq!(
+            test_decode::<CacheControl>(&["must-understand"]).unwrap(),
+            cc
+        );
         assert!(cc.must_understand());
     }
 

--- a/src/common/cache_control.rs
+++ b/src/common/cache_control.rs
@@ -59,6 +59,7 @@ impl Flags {
     const PRIVATE: Self = Self { bits: 0b001000000 };
     const PROXY_REVALIDATE: Self = Self { bits: 0b010000000 };
     const IMMUTABLE: Self = Self { bits: 0b100000000 };
+    const MUST_UNDERSTAND: Self = Self { bits: 0b1000000000 };
 
     fn empty() -> Self {
         Self { bits: 0 }
@@ -120,6 +121,10 @@ impl CacheControl {
     /// Check if the `immutable` directive is set.
     pub fn immutable(&self) -> bool {
         self.flags.contains(Flags::IMMUTABLE)
+    }
+    /// Check if the `must_understand` directive is set.
+    pub fn must_understand(&self) -> bool {
+        self.flags.contains(Flags::MUST_UNDERSTAND)
     }
 
     /// Get the value of the `max-age` directive if set.
@@ -186,6 +191,11 @@ impl CacheControl {
         self
     }
 
+    /// Set the `must_understand` directive.
+    pub fn with_must_understand(mut self) -> Self {
+        self.flags.insert(Flags::MUST_UNDERSTAND);
+        self
+    }
     /// Set the `max-age` directive.
     pub fn with_max_age(mut self, duration: Duration) -> Self {
         self.max_age = Some(duration.into());
@@ -258,6 +268,9 @@ impl FromIterator<KnownDirective> for FromIter {
                 Directive::MustRevalidate => {
                     cc.flags.insert(Flags::MUST_REVALIDATE);
                 }
+                Directive::MustUnderstand => {
+                    cc.flags.insert(Flags::MUST_UNDERSTAND);
+                 }
                 Directive::Public => {
                     cc.flags.insert(Flags::PUBLIC);
                 }
@@ -310,6 +323,7 @@ impl<'a> fmt::Display for Fmt<'a> {
             if_flag(Flags::PUBLIC, Directive::Public),
             if_flag(Flags::PRIVATE, Directive::Private),
             if_flag(Flags::IMMUTABLE, Directive::Immutable),
+            if_flag(Flags::MUST_UNDERSTAND, Directive::MustUnderstand),
             if_flag(Flags::PROXY_REVALIDATE, Directive::ProxyRevalidate),
             self.0
                 .max_age
@@ -355,6 +369,7 @@ enum Directive {
 
     // response directives
     MustRevalidate,
+    MustUnderstand,
     Public,
     Private,
     Immutable,
@@ -376,6 +391,7 @@ impl fmt::Display for Directive {
                 Directive::MinFresh(secs) => return write!(f, "min-fresh={}", secs),
 
                 Directive::MustRevalidate => "must-revalidate",
+                Directive::MustUnderstand => "must-understand",
                 Directive::Public => "public",
                 Directive::Private => "private",
                 Directive::Immutable => "immutable",
@@ -399,6 +415,7 @@ impl FromStr for KnownDirective {
             "public" => Directive::Public,
             "private" => Directive::Private,
             "immutable" => Directive::Immutable,
+            "must-understand" => Directive::MustUnderstand,
             "proxy-revalidate" => Directive::ProxyRevalidate,
             "" => return Err(()),
             _ => match s.find('=') {
@@ -470,6 +487,15 @@ mod tests {
         assert_eq!(headers["cache-control"], "immutable");
         assert_eq!(test_decode::<CacheControl>(&["immutable"]).unwrap(), cc);
         assert!(cc.immutable());
+    }
+
+    #[test]
+    fn test_must_understand() {
+        let cc = CacheControl::new().with_must_understand();
+        let headers = test_encode(cc.clone());
+        assert_eq!(headers["cache-control"], "must-understand");
+        assert_eq!(test_decode::<CacheControl>(&["must-understand"]).unwrap(), cc);
+        assert!(cc.must_understand());
     }
 
     #[test]


### PR DESCRIPTION
While working with Cache Control on another project, I noticed that the "must-understand" directive was missing.

I followed along the lines of a previous contribution, let me know if there's anything that is missing or incorrect and I'll be glad to work it through.