### PR TITLE
 doc(core): Header encode method convert header to HeaderValue

### DIFF
--- a/headers-core/src/lib.rs
+++ b/headers-core/src/lib.rs
@@ -29,7 +29,8 @@ pub trait Header {
         Self: Sized,
         I: Iterator<Item = &'i HeaderValue>;
 
-    /// Encode this type to a [`HeaderValue`].
+    /// Encode this type to a [`HeaderValue`], and add it to a container
+    /// which has [`HeaderValue`] type as each element.
     ///
     /// This function should be infallible. Any errors converting to a
     /// `HeaderValue` should have been caught when parsing or constructing

--- a/headers-core/src/lib.rs
+++ b/headers-core/src/lib.rs
@@ -29,7 +29,7 @@ pub trait Header {
         Self: Sized,
         I: Iterator<Item = &'i HeaderValue>;
 
-    /// Encode this type to a `HeaderMap`.
+    /// Encode this type to a `HeaderValue`.
     ///
     /// This function should be infallible. Any errors converting to a
     /// `HeaderValue` should have been caught when parsing or constructing

--- a/headers-core/src/lib.rs
+++ b/headers-core/src/lib.rs
@@ -23,13 +23,13 @@ pub trait Header {
     /// The name of this header.
     fn name() -> &'static HeaderName;
 
-    /// Decode this type from an iterator of `HeaderValue`s.
+    /// Decode this type from an iterator of [`HeaderValue`]s.
     fn decode<'i, I>(values: &mut I) -> Result<Self, Error>
     where
         Self: Sized,
         I: Iterator<Item = &'i HeaderValue>;
 
-    /// Encode this type to a `HeaderValue`.
+    /// Encode this type to a [`HeaderValue`].
     ///
     /// This function should be infallible. Any errors converting to a
     /// `HeaderValue` should have been caught when parsing or constructing


### PR DESCRIPTION
`Header`'s `encode` method seems to convert the receiver to `HeaderValue`.