### PR TITLE
feat: permit reference types for typed_insert

### DIFF
--- a/src/common/accept_ranges.rs
+++ b/src/common/accept_ranges.rs
@@ -26,7 +26,7 @@ use util::FlatCsv;
 ///
 /// let mut headers = HeaderMap::new();
 ///
-/// headers.typed_insert(AcceptRanges::bytes());
+/// headers.typed_insert(&AcceptRanges::bytes());
 /// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct AcceptRanges(FlatCsv);

--- a/src/common/authorization.rs
+++ b/src/common/authorization.rs
@@ -232,7 +232,7 @@ mod tests {
     fn basic_roundtrip() {
         let auth = Authorization::basic("Aladdin", "open sesame");
         let mut h = HeaderMap::new();
-        h.typed_insert(auth.clone());
+        h.typed_insert(&auth);
         assert_eq!(h.typed_get(), Some(auth));
     }
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -83,7 +83,7 @@ fn test_decode<T: ::Header>(values: &[&str]) -> Option<T> {
 fn test_encode<T: ::Header>(header: T) -> ::http::HeaderMap {
     use HeaderMapExt;
     let mut map = ::http::HeaderMap::new();
-    map.typed_insert(header);
+    map.typed_insert(&header);
     map
 }
 
@@ -118,7 +118,7 @@ macro_rules! bench_header {
                 let typed = map.typed_get::<$ty>().unwrap();
                 b.bytes = $value.len() as u64;
                 b.iter(|| {
-                    map.typed_insert(typed.clone());
+                    map.typed_insert(&typed);
                     map.clear();
                 });
             }

--- a/src/map_ext.rs
+++ b/src/map_ext.rs
@@ -4,7 +4,7 @@ use http;
 /// An extension trait adding "typed" methods to `http::HeaderMap`.
 pub trait HeaderMapExt: self::sealed::Sealed {
     /// Inserts the typed `Header` into this `HeaderMap`.
-    fn typed_insert<H>(&mut self, header: H)
+    fn typed_insert<H>(&mut self, header: &H)
     where
         H: Header;
 
@@ -20,7 +20,7 @@ pub trait HeaderMapExt: self::sealed::Sealed {
 }
 
 impl HeaderMapExt for http::HeaderMap {
-    fn typed_insert<H>(&mut self, header: H)
+    fn typed_insert<H>(&mut self, header: &H)
     where
         H: Header,
     {


### PR DESCRIPTION
`typed_insert` doesn't need owned references, makes sense to extend that liberty to the caller.

We can save on unnecessary allocations.