### PR TITLE
fix: avoid treating empty values as valid CSV input

### DIFF
--- a/src/common/if_match.rs
+++ b/src/common/if_match.rs
@@ -72,7 +72,28 @@ impl From<ETag> for IfMatch {
 
 #[cfg(test)]
 mod tests {
+    use super::super::test_decode;
     use super::*;
+
+    #[test]
+    fn test_empty() {
+        assert_eq!(test_decode::<IfMatch>(&[]), None);
+    }
+
+    #[test]
+    fn test_invalid() {
+        assert_eq!(test_decode::<IfMatch>(&[""]), None);
+        assert_eq!(test_decode::<IfMatch>(&["  "]), None);
+        assert_eq!(test_decode::<IfMatch>(&["foo"]), None);
+    }
+
+    #[test]
+    fn test_valid() {
+        assert_eq!(
+            test_decode::<IfMatch>(&["\"foo\""]),
+            Some(IfMatch::from(ETag::from_static("\"foo\"")))
+        );
+    }
 
     #[test]
     fn is_any() {

--- a/src/util/entity.rs
+++ b/src/util/entity.rs
@@ -254,6 +254,9 @@ impl super::TryFromValues for EntityTagRange {
         if flat.value == "*" {
             Ok(EntityTagRange::Any)
         } else {
+            for tag in flat.iter() {
+                EntityTag::parse(tag.as_bytes()).ok_or_else(::Error::invalid)?;
+            }
             Ok(EntityTagRange::Tags(flat))
         }
     }

--- a/src/util/flat_csv.rs
+++ b/src/util/flat_csv.rs
@@ -66,6 +66,9 @@ impl<Sep: Separator> TryFromValues for FlatCsv<Sep> {
     where
         I: Iterator<Item = &'i HeaderValue>,
     {
+        let mut values = values.peekable();
+        values.peek().ok_or_else(::Error::invalid)?;
+
         let flat = values.collect();
         Ok(flat)
     }


### PR DESCRIPTION
While using Axum, I noticed `If-Match` & `If-None-Match` would always default to `Some("")` making it difficult to know if the user passed the headers as `If-Match:` or not at all.

I looked into the code, and it turns out the logic for consuming the values iterator [defaults to an empty byte array](https://github.com/hyperium/headers/blob/0f7c1c68105d747d9b3053e5ec2d8a4c09d2fc9d/src/util/flat_csv.rs#L116) (ergo, empty string)

I chose this peeking method and short-circuiting before calling `collect` to avoid more complex patterns.

And tags in `If-Match` & `If-None-Match` (depending on `EntityTagRange`) weren't being validated.

This fixes that.