### PR TITLE
Add integration with request builder and response builder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,9 @@ mod util;
 mod common;
 mod map_ext;
 mod request_builder_ext;
+mod response_builder_ext;
 
 pub use self::common::*;
 pub use self::map_ext::HeaderMapExt;
 pub use self::request_builder_ext::RequestBuilderExt;
+pub use self::response_builder_ext::ResponseBuilderExt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,8 @@ pub use http::header::{HeaderName, HeaderValue};
 mod util;
 mod common;
 mod map_ext;
+mod request_builder_ext;
 
 pub use self::common::*;
 pub use self::map_ext::HeaderMapExt;
+pub use self::request_builder_ext::RequestBuilderExt;

--- a/src/request_builder_ext.rs
+++ b/src/request_builder_ext.rs
@@ -1,0 +1,38 @@
+use crate::{Header, HeaderMapExt};
+
+/// An external trait adding helper methods to http request builder.
+pub trait RequestBuilderExt: self::sealed::Sealed {
+    /// Appends a typed header to this request builder.
+    fn typed_header(self, header: impl Header) -> Self;
+}
+
+impl RequestBuilderExt for http::request::Builder {
+    fn typed_header(mut self, header: impl Header) -> Self {
+        self.headers_mut()
+            .map(|header_map| header_map.typed_insert(header));
+        self
+    }
+}
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for http::request::Builder {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RequestBuilderExt;
+
+    #[test]
+    fn test_with_header_map_get_method() {
+        let request = http::Request::builder()
+            .typed_header(crate::ContentType::text())
+            .body(())
+            .unwrap();
+
+        assert_eq!(
+            request.headers().get(http::header::CONTENT_TYPE).unwrap(),
+            "text/plain",
+        );
+    }
+}

--- a/src/response_builder_ext.rs
+++ b/src/response_builder_ext.rs
@@ -1,0 +1,38 @@
+use crate::{Header, HeaderMapExt};
+
+/// An external trait adding helper methods to http response builder.
+pub trait ResponseBuilderExt: self::sealed::Sealed {
+    /// Appends a typed header to this response builder.
+    fn typed_header(self, header: impl Header) -> Self;
+}
+
+impl ResponseBuilderExt for http::response::Builder {
+    fn typed_header(mut self, header: impl Header) -> Self {
+        self.headers_mut()
+            .map(|header_map| header_map.typed_insert(header));
+        self
+    }
+}
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for http::response::Builder {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ResponseBuilderExt;
+
+    #[test]
+    fn test_with_header_map_get_method() {
+        let response = http::Response::builder()
+            .typed_header(crate::ContentType::text())
+            .body(())
+            .unwrap();
+
+        assert_eq!(
+            response.headers().get(http::header::CONTENT_TYPE).unwrap(),
+            "text/plain",
+        );
+    }
+}


### PR DESCRIPTION
Adds integrations with request builder and response builder. These provide easy ways to set typed headers when building request and response.