### PR TITLE
chore(core): set msrv to 1.49

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,5 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Install rust ${{ env.minrust }}
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.minrust }}
-      - run: cargo build
+      - uses: taiki-e/install-action@cargo-hack
+      - run: cargo hack --rust-version --no-dev-deps check --workspace

--- a/headers-core/Cargo.toml
+++ b/headers-core/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://hyper.rs"
 repository = "https://github.com/hyperium/headers"
 authors = ["Sean McArthur <sean@seanmonstar.com>"]
 keywords = ["http", "headers", "hyper", "hyperium"]
+rust-version = "1.49"
 
 [dependencies]
 http = "1.0.0"


### PR DESCRIPTION
Sets `headers-core`'s msrv to 1.49, the same version of `http` which is the only crate `headers-core` depends on.