### PR TITLE
refactor: remove unnecessary extern crate sentence

### DIFF
--- a/src/common/access_control_allow_credentials.rs
+++ b/src/common/access_control_allow_credentials.rs
@@ -27,7 +27,6 @@ use crate::{Error, Header};
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::AccessControlAllowCredentials;
 ///
 /// let allow_creds = AccessControlAllowCredentials;

--- a/src/common/access_control_allow_headers.rs
+++ b/src/common/access_control_allow_headers.rs
@@ -23,7 +23,6 @@ use crate::util::FlatCsv;
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// extern crate http;
 /// use http::header::{CACHE_CONTROL, CONTENT_TYPE};
 /// use headers::AccessControlAllowHeaders;

--- a/src/common/access_control_allow_methods.rs
+++ b/src/common/access_control_allow_methods.rs
@@ -23,7 +23,6 @@ use crate::util::FlatCsv;
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// extern crate http;
 /// use http::Method;
 /// use headers::AccessControlAllowMethods;

--- a/src/common/access_control_allow_origin.rs
+++ b/src/common/access_control_allow_origin.rs
@@ -27,7 +27,6 @@ use crate::Error;
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::AccessControlAllowOrigin;
 /// use std::convert::TryFrom;
 ///

--- a/src/common/access_control_expose_headers.rs
+++ b/src/common/access_control_expose_headers.rs
@@ -22,7 +22,6 @@ use crate::util::FlatCsv;
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// extern crate http;
 /// # fn main() {
 /// use http::header::{CONTENT_LENGTH, ETAG};

--- a/src/common/access_control_max_age.rs
+++ b/src/common/access_control_max_age.rs
@@ -21,7 +21,6 @@ use crate::util::Seconds;
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// use std::time::Duration;
 /// use headers::AccessControlMaxAge;
 ///

--- a/src/common/access_control_request_headers.rs
+++ b/src/common/access_control_request_headers.rs
@@ -23,7 +23,6 @@ use crate::util::FlatCsv;
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// extern crate http;
 /// # fn main() {
 /// use http::header::{ACCEPT_LANGUAGE, DATE};

--- a/src/common/access_control_request_method.rs
+++ b/src/common/access_control_request_method.rs
@@ -19,7 +19,6 @@ use crate::{Error, Header};
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// extern crate http;
 /// use headers::AccessControlRequestMethod;
 /// use http::Method;

--- a/src/common/age.rs
+++ b/src/common/age.rs
@@ -31,7 +31,6 @@ use crate::util::Seconds;
 /// # Example
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::Age;
 ///
 /// let len = Age::from_secs(60);

--- a/src/common/allow.rs
+++ b/src/common/allow.rs
@@ -25,7 +25,6 @@ use crate::util::FlatCsv;
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// extern crate http;
 /// use headers::Allow;
 /// use http::Method;

--- a/src/common/authorization.rs
+++ b/src/common/authorization.rs
@@ -29,7 +29,6 @@ use crate::{Error, Header};
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::Authorization;
 ///
 /// let basic = Authorization::basic("Aladdin", "open sesame");

--- a/src/common/cache_control.rs
+++ b/src/common/cache_control.rs
@@ -32,7 +32,6 @@ use crate::{Error, Header};
 /// # Example
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::CacheControl;
 ///
 /// let cc = CacheControl::new();

--- a/src/common/connection.rs
+++ b/src/common/connection.rs
@@ -29,7 +29,6 @@ use crate::util::FlatCsv;
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::Connection;
 ///
 /// let keep_alive = Connection::keep_alive();
@@ -73,7 +72,6 @@ impl Connection {
     /// # Example
     ///
     /// ```
-    /// # extern crate headers;
     /// extern crate http;
     ///
     /// use http::header::UPGRADE;

--- a/src/common/content_disposition.rs
+++ b/src/common/content_disposition.rs
@@ -42,7 +42,6 @@ use crate::{Error, Header};
 /// # Example
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::ContentDisposition;
 ///
 /// let cd = ContentDisposition::inline();

--- a/src/common/content_encoding.rs
+++ b/src/common/content_encoding.rs
@@ -28,7 +28,6 @@ use crate::util::FlatCsv;
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::ContentEncoding;
 ///
 /// let content_enc = ContentEncoding::gzip();
@@ -63,7 +62,6 @@ impl ContentEncoding {
     /// # Example
     ///
     /// ```
-    /// # extern crate headers;
     /// use headers::ContentEncoding;
     ///
     /// let content_enc = ContentEncoding::gzip();

--- a/src/common/content_length.rs
+++ b/src/common/content_length.rs
@@ -34,7 +34,6 @@ use crate::{Error, Header};
 /// # Example
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::ContentLength;
 ///
 /// let len = ContentLength(1_000);

--- a/src/common/content_range.rs
+++ b/src/common/content_range.rs
@@ -29,7 +29,6 @@ use crate::{util, Error, Header};
 /// # Example
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::ContentRange;
 ///
 /// // 100 bytes (included byte 199), with a full length of 3,400

--- a/src/common/content_type.rs
+++ b/src/common/content_type.rs
@@ -34,7 +34,6 @@ use crate::{Error, Header};
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::ContentType;
 ///
 /// let ct = ContentType::json();

--- a/src/common/cookie.rs
+++ b/src/common/cookie.rs
@@ -27,7 +27,6 @@ impl Cookie {
     /// # Example
     ///
     /// ```
-    /// # extern crate headers;
     /// use headers::{Cookie, HeaderMap, HeaderMapExt, HeaderValue};
     ///
     /// // Setup the header map with strings...

--- a/src/common/date.rs
+++ b/src/common/date.rs
@@ -20,7 +20,6 @@ use crate::util::HttpDate;
 /// # Example
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::Date;
 /// use std::time::SystemTime;
 ///

--- a/src/common/expect.rs
+++ b/src/common/expect.rs
@@ -17,7 +17,6 @@ use crate::{Error, Header};
 /// # Example
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::Expect;
 ///
 /// let expect = Expect::CONTINUE;

--- a/src/common/expires.rs
+++ b/src/common/expires.rs
@@ -23,7 +23,6 @@ use crate::util::HttpDate;
 /// # Example
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::Expires;
 /// use std::time::{SystemTime, Duration};
 ///

--- a/src/common/if_match.rs
+++ b/src/common/if_match.rs
@@ -32,7 +32,6 @@ use crate::util::EntityTagRange;
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::IfMatch;
 ///
 /// let if_match = IfMatch::any();

--- a/src/common/if_modified_since.rs
+++ b/src/common/if_modified_since.rs
@@ -22,7 +22,6 @@ use std::time::SystemTime;
 /// # Example
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::IfModifiedSince;
 /// use std::time::{Duration, SystemTime};
 ///

--- a/src/common/if_none_match.rs
+++ b/src/common/if_none_match.rs
@@ -34,7 +34,6 @@ use crate::util::EntityTagRange;
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::IfNoneMatch;
 ///
 /// let if_none_match = IfNoneMatch::any();

--- a/src/common/if_range.rs
+++ b/src/common/if_range.rs
@@ -35,7 +35,6 @@ use crate::Error;
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::IfRange;
 /// use std::time::{SystemTime, Duration};
 ///

--- a/src/common/if_unmodified_since.rs
+++ b/src/common/if_unmodified_since.rs
@@ -23,7 +23,6 @@ use std::time::SystemTime;
 /// # Example
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::IfUnmodifiedSince;
 /// use std::time::{SystemTime, Duration};
 ///

--- a/src/common/last_modified.rs
+++ b/src/common/last_modified.rs
@@ -22,7 +22,6 @@ use std::time::SystemTime;
 /// # Example
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::LastModified;
 /// use std::time::{Duration, SystemTime};
 ///

--- a/src/common/origin.rs
+++ b/src/common/origin.rs
@@ -21,7 +21,6 @@ use crate::Error;
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::Origin;
 ///
 /// let origin = Origin::NULL;

--- a/src/common/pragma.rs
+++ b/src/common/pragma.rs
@@ -18,7 +18,6 @@ use http::HeaderValue;
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::Pragma;
 ///
 /// let pragma = Pragma::no_cache();

--- a/src/common/range.rs
+++ b/src/common/range.rs
@@ -37,7 +37,6 @@ use crate::{Error, Header};
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::Range;
 ///
 ///

--- a/src/common/referer.rs
+++ b/src/common/referer.rs
@@ -25,7 +25,6 @@ use crate::util::HeaderValueString;
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::Referer;
 ///
 /// let r = Referer::from_static("/People.html#tim");

--- a/src/common/referrer_policy.rs
+++ b/src/common/referrer_policy.rs
@@ -28,7 +28,6 @@ use crate::Error;
 /// # Example
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::ReferrerPolicy;
 ///
 /// let rp = ReferrerPolicy::NO_REFERRER;

--- a/src/common/retry_after.rs
+++ b/src/common/retry_after.rs
@@ -17,7 +17,6 @@ use crate::Error;
 ///
 /// # Examples
 /// ```
-/// # extern crate headers;
 /// use std::time::{Duration, SystemTime};
 /// use headers::RetryAfter;
 ///

--- a/src/common/sec_websocket_accept.rs
+++ b/src/common/sec_websocket_accept.rs
@@ -15,7 +15,6 @@ use super::SecWebsocketKey;
 /// # Example
 ///
 /// ```no_run
-/// # extern crate headers;
 /// use headers::{SecWebsocketAccept, SecWebsocketKey};
 ///
 /// let sec_key: SecWebsocketKey = /* from request headers */

--- a/src/common/server.rs
+++ b/src/common/server.rs
@@ -25,7 +25,6 @@ use crate::util::HeaderValueString;
 /// # Example
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::Server;
 ///
 /// let server = Server::from_static("hyper/0.12.2");

--- a/src/common/strict_transport_security.rs
+++ b/src/common/strict_transport_security.rs
@@ -35,7 +35,6 @@ use crate::{Error, Header};
 /// # Example
 ///
 /// ```
-/// # extern crate headers;
 /// use std::time::Duration;
 /// use headers::StrictTransportSecurity;
 ///

--- a/src/common/transfer_encoding.rs
+++ b/src/common/transfer_encoding.rs
@@ -31,7 +31,6 @@ use crate::util::FlatCsv;
 /// # Example
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::TransferEncoding;
 ///
 /// let transfer = TransferEncoding::chunked();

--- a/src/common/upgrade.rs
+++ b/src/common/upgrade.rs
@@ -34,7 +34,6 @@ use http::HeaderValue;
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::Upgrade;
 ///
 /// let ws = Upgrade::websocket();

--- a/src/common/user_agent.rs
+++ b/src/common/user_agent.rs
@@ -34,7 +34,6 @@ use crate::util::HeaderValueString;
 /// # Example
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::UserAgent;
 ///
 /// let ua = UserAgent::from_static("hyper/0.12.2");

--- a/src/common/vary.rs
+++ b/src/common/vary.rs
@@ -24,7 +24,6 @@ use crate::util::FlatCsv;
 /// # Example
 ///
 /// ```
-/// # extern crate headers;
 /// use headers::Vary;
 ///
 /// let vary = Vary::any();

--- a/src/disabled/accept.rs
+++ b/src/disabled/accept.rs
@@ -30,7 +30,6 @@ header! {
     ///
     /// # Examples
     /// ```
-    /// # extern crate headers;
     /// extern crate mime;
     /// use headers::{Headers, Accept, qitem};
     ///
@@ -44,7 +43,6 @@ header! {
     /// ```
     ///
     /// ```
-    /// # extern crate headers;
     /// extern crate mime;
     /// use headers::{Headers, Accept, qitem};
     ///
@@ -56,7 +54,6 @@ header! {
     /// );
     /// ```
     /// ```
-    /// # extern crate headers;
     /// extern crate mime;
     /// use headers::{Headers, Accept, QualityItem, q, qitem};
     ///

--- a/src/disabled/accept_language.rs
+++ b/src/disabled/accept_language.rs
@@ -37,7 +37,6 @@ header! {
     /// ```
     ///
     /// ```
-    /// # extern crate headers;
     /// # #[macro_use] extern crate language_tags;
     /// # use headers::{Headers, AcceptLanguage, QualityItem, q, qitem};
     /// #

--- a/src/disabled/content_language.rs
+++ b/src/disabled/content_language.rs
@@ -22,7 +22,6 @@ use util::FlatCsv;
 /// # Examples
 ///
 /// ```
-/// # extern crate headers;
 /// #[macro_use] extern crate language_tags;
 /// use headers::ContentLanguage;
 /// #

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,13 +72,6 @@
 //! }
 //! ```
 
-extern crate base64;
-extern crate bytes;
-extern crate headers_core;
-extern crate http;
-extern crate httpdate;
-extern crate mime;
-extern crate sha1;
 #[cfg(all(test, feature = "nightly"))]
 extern crate test;
 


### PR DESCRIPTION
Removes unnecessary `extern crate` sentences. Leaves the ones which are visible in the documents for the 2015 edition users since `headers` also supports the rust versions which only support 2015 edition.