### PR TITLE
feat: re-export mime::Mime

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,8 @@ extern crate test;
 
 pub use headers_core::{Error, Header};
 
+pub use mime::Mime;
+
 #[doc(hidden)]
 pub use http::HeaderMap;
 


### PR DESCRIPTION
Re-exports `mime::Mime`. This struct has already been an external type as [`ContentType`](https://docs.rs/headers/latest/headers/struct.ContentType.html#). Especially when users convert from `Mime` to `ContentType`, this would be useful.