### PR TITLE
update IETF rfc links in docs

### DIFF
--- a/src/common/accept_ranges.rs
+++ b/src/common/accept_ranges.rs
@@ -2,7 +2,7 @@ use http::HeaderValue;
 
 use crate::util::FlatCsv;
 
-/// `Accept-Ranges` header, defined in [RFC7233](http://tools.ietf.org/html/rfc7233#section-2.3)
+/// `Accept-Ranges` header, defined in [RFC7233](https://datatracker.ietf.org/doc/html/rfc7233#section-2.3)
 ///
 /// The `Accept-Ranges` header field allows a server to indicate that it
 /// supports range requests for the target resource.

--- a/src/common/allow.rs
+++ b/src/common/allow.rs
@@ -4,7 +4,7 @@ use http::{HeaderValue, Method};
 
 use crate::util::FlatCsv;
 
-/// `Allow` header, defined in [RFC7231](http://tools.ietf.org/html/rfc7231#section-7.4.1)
+/// `Allow` header, defined in [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-7.4.1)
 ///
 /// The `Allow` header field lists the set of methods advertised as
 /// supported by the target resource.  The purpose of this field is

--- a/src/common/connection.rs
+++ b/src/common/connection.rs
@@ -6,7 +6,7 @@ use self::sealed::AsConnectionOption;
 use crate::util::FlatCsv;
 
 /// `Connection` header, defined in
-/// [RFC7230](http://tools.ietf.org/html/rfc7230#section-6.1)
+/// [RFC7230](https://datatracker.ietf.org/doc/html/rfc7230#section-6.1)
 ///
 /// The `Connection` header field allows the sender to indicate desired
 /// control options for the current connection.  In order to avoid

--- a/src/common/content_encoding.rs
+++ b/src/common/content_encoding.rs
@@ -4,7 +4,7 @@ use self::sealed::AsCoding;
 use crate::util::FlatCsv;
 
 /// `Content-Encoding` header, defined in
-/// [RFC7231](http://tools.ietf.org/html/rfc7231#section-3.1.2.2)
+/// [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.2.2)
 ///
 /// The `Content-Encoding` header field indicates what content codings
 /// have been applied to the representation, beyond those inherent in the

--- a/src/common/content_length.rs
+++ b/src/common/content_length.rs
@@ -3,7 +3,7 @@ use http::HeaderValue;
 use crate::{Error, Header};
 
 /// `Content-Length` header, defined in
-/// [RFC7230](http://tools.ietf.org/html/rfc7230#section-3.3.2)
+/// [RFC7230](https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2)
 ///
 /// When a message does not have a `Transfer-Encoding` header field, a
 /// Content-Length header field can provide the anticipated size, as a
@@ -16,7 +16,7 @@ use crate::{Error, Header};
 ///
 /// Note that setting this header will *remove* any previously set
 /// `Transfer-Encoding` header, in accordance with
-/// [RFC7230](http://tools.ietf.org/html/rfc7230#section-3.3.2):
+/// [RFC7230](https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2):
 ///
 /// > A sender MUST NOT send a Content-Length header field in any message
 /// > that contains a Transfer-Encoding header field.

--- a/src/common/content_type.rs
+++ b/src/common/content_type.rs
@@ -6,7 +6,7 @@ use mime::Mime;
 use crate::{Error, Header};
 
 /// `Content-Type` header, defined in
-/// [RFC7231](http://tools.ietf.org/html/rfc7231#section-3.1.1.5)
+/// [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.5)
 ///
 /// The `Content-Type` header field indicates the media type of the
 /// associated representation: either the representation enclosed in the

--- a/src/common/cookie.rs
+++ b/src/common/cookie.rs
@@ -1,6 +1,6 @@
 use crate::util::{FlatCsv, SemiColon};
 
-/// `Cookie` header, defined in [RFC6265](http://tools.ietf.org/html/rfc6265#section-5.4)
+/// `Cookie` header, defined in [RFC6265](https://datatracker.ietf.org/doc/html/rfc6265#section-5.4)
 ///
 /// If the user agent does attach a Cookie header field to an HTTP
 /// request, the user agent must send the cookie-string

--- a/src/common/date.rs
+++ b/src/common/date.rs
@@ -2,7 +2,7 @@ use std::time::SystemTime;
 
 use crate::util::HttpDate;
 
-/// `Date` header, defined in [RFC7231](http://tools.ietf.org/html/rfc7231#section-7.1.1.2)
+/// `Date` header, defined in [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.2)
 ///
 /// The `Date` header field represents the date and time at which the
 /// message was originated.

--- a/src/common/etag.rs
+++ b/src/common/etag.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use crate::util::EntityTag;
 
-/// `ETag` header, defined in [RFC7232](http://tools.ietf.org/html/rfc7232#section-2.3)
+/// `ETag` header, defined in [RFC7232](https://datatracker.ietf.org/doc/html/rfc7232#section-2.3)
 ///
 /// The `ETag` header field in a response provides the current entity-tag
 /// for the selected representation, as determined at the conclusion of

--- a/src/common/expires.rs
+++ b/src/common/expires.rs
@@ -2,7 +2,7 @@ use std::time::SystemTime;
 
 use crate::util::HttpDate;
 
-/// `Expires` header, defined in [RFC7234](http://tools.ietf.org/html/rfc7234#section-5.3)
+/// `Expires` header, defined in [RFC7234](https://datatracker.ietf.org/doc/html/rfc7234#section-5.3)
 ///
 /// The `Expires` header field gives the date/time after which the
 /// response is considered stale.

--- a/src/common/if_modified_since.rs
+++ b/src/common/if_modified_since.rs
@@ -2,7 +2,7 @@ use crate::util::HttpDate;
 use std::time::SystemTime;
 
 /// `If-Modified-Since` header, defined in
-/// [RFC7232](http://tools.ietf.org/html/rfc7232#section-3.3)
+/// [RFC7232](https://datatracker.ietf.org/doc/html/rfc7232#section-3.3)
 ///
 /// The `If-Modified-Since` header field makes a GET or HEAD request
 /// method conditional on the selected representation's modification date

--- a/src/common/if_range.rs
+++ b/src/common/if_range.rs
@@ -6,7 +6,7 @@ use super::{ETag, LastModified};
 use crate::util::{EntityTag, HttpDate, TryFromValues};
 use crate::Error;
 
-/// `If-Range` header, defined in [RFC7233](http://tools.ietf.org/html/rfc7233#section-3.2)
+/// `If-Range` header, defined in [RFC7233](https://datatracker.ietf.org/doc/html/rfc7233#section-3.2)
 ///
 /// If a client has a partial copy of a representation and wishes to have
 /// an up-to-date copy of the entire representation, it could use the

--- a/src/common/if_unmodified_since.rs
+++ b/src/common/if_unmodified_since.rs
@@ -2,7 +2,7 @@ use crate::util::HttpDate;
 use std::time::SystemTime;
 
 /// `If-Unmodified-Since` header, defined in
-/// [RFC7232](http://tools.ietf.org/html/rfc7232#section-3.4)
+/// [RFC7232](https://datatracker.ietf.org/doc/html/rfc7232#section-3.4)
 ///
 /// The `If-Unmodified-Since` header field makes the request method
 /// conditional on the selected representation's last modification date

--- a/src/common/last_modified.rs
+++ b/src/common/last_modified.rs
@@ -2,7 +2,7 @@ use crate::util::HttpDate;
 use std::time::SystemTime;
 
 /// `Last-Modified` header, defined in
-/// [RFC7232](http://tools.ietf.org/html/rfc7232#section-2.2)
+/// [RFC7232](https://datatracker.ietf.org/doc/html/rfc7232#section-2.2)
 ///
 /// The `Last-Modified` header field in a response provides a timestamp
 /// indicating the date and time at which the origin server believes the

--- a/src/common/location.rs
+++ b/src/common/location.rs
@@ -1,7 +1,7 @@
 use http::HeaderValue;
 
 /// `Location` header, defined in
-/// [RFC7231](http://tools.ietf.org/html/rfc7231#section-7.1.2)
+/// [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.2)
 ///
 /// The `Location` header field is used in some responses to refer to a
 /// specific resource in relation to the response.  The type of

--- a/src/common/referer.rs
+++ b/src/common/referer.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use crate::util::HeaderValueString;
 
 /// `Referer` header, defined in
-/// [RFC7231](http://tools.ietf.org/html/rfc7231#section-5.5.2)
+/// [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.2)
 ///
 /// The `Referer` \[sic\] header field allows the user agent to specify a
 /// URI reference for the resource from which the target URI was obtained

--- a/src/common/retry_after.rs
+++ b/src/common/retry_after.rs
@@ -24,7 +24,7 @@ use crate::Error;
 /// let date = RetryAfter::date(SystemTime::now());
 /// ```
 
-/// Retry-After header, defined in [RFC7231](http://tools.ietf.org/html/rfc7231#section-7.1.3)
+/// Retry-After header, defined in [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.3)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RetryAfter(After);
 

--- a/src/common/server.rs
+++ b/src/common/server.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 use crate::util::HeaderValueString;
 
-/// `Server` header, defined in [RFC7231](http://tools.ietf.org/html/rfc7231#section-7.4.2)
+/// `Server` header, defined in [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-7.4.2)
 ///
 /// The `Server` header field contains information about the software
 /// used by the origin server to handle the request, which is often used

--- a/src/common/set_cookie.rs
+++ b/src/common/set_cookie.rs
@@ -2,7 +2,7 @@ use http::{HeaderName, HeaderValue};
 
 use crate::{Error, Header};
 
-/// `Set-Cookie` header, defined [RFC6265](http://tools.ietf.org/html/rfc6265#section-4.1)
+/// `Set-Cookie` header, defined [RFC6265](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1)
 ///
 /// The Set-Cookie HTTP response header is used to send cookies from the
 /// server to the user agent.

--- a/src/common/te.rs
+++ b/src/common/te.rs
@@ -3,7 +3,7 @@ use http::HeaderValue;
 use crate::util::FlatCsv;
 
 /// `TE` header, defined in
-/// [RFC7230](http://tools.ietf.org/html/rfc7230#section-4.3)
+/// [RFC7230](https://datatracker.ietf.org/doc/html/rfc7230#section-4.3)
 ///
 /// As RFC7230 states, "The "TE" header field in a request indicates what transfer codings,
 /// besides chunked, the client is willing to accept in response, and

--- a/src/common/transfer_encoding.rs
+++ b/src/common/transfer_encoding.rs
@@ -3,7 +3,7 @@ use http::HeaderValue;
 use crate::util::FlatCsv;
 
 /// `Transfer-Encoding` header, defined in
-/// [RFC7230](http://tools.ietf.org/html/rfc7230#section-3.3.1)
+/// [RFC7230](https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.1)
 ///
 /// The `Transfer-Encoding` header field lists the transfer coding names
 /// corresponding to the sequence of transfer codings that have been (or
@@ -12,7 +12,7 @@ use crate::util::FlatCsv;
 ///
 /// Note that setting this header will *remove* any previously set
 /// `Content-Length` header, in accordance with
-/// [RFC7230](http://tools.ietf.org/html/rfc7230#section-3.3.2):
+/// [RFC7230](https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2):
 ///
 /// > A sender MUST NOT send a Content-Length header field in any message
 /// > that contains a Transfer-Encoding header field.

--- a/src/common/upgrade.rs
+++ b/src/common/upgrade.rs
@@ -1,6 +1,6 @@
 use http::HeaderValue;
 
-/// `Upgrade` header, defined in [RFC7230](http://tools.ietf.org/html/rfc7230#section-6.7)
+/// `Upgrade` header, defined in [RFC7230](https://datatracker.ietf.org/doc/html/rfc7230#section-6.7)
 ///
 /// The `Upgrade` header field is intended to provide a simple mechanism
 /// for transitioning from HTTP/1.1 to some other protocol on the same

--- a/src/common/user_agent.rs
+++ b/src/common/user_agent.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use crate::util::HeaderValueString;
 
 /// `User-Agent` header, defined in
-/// [RFC7231](http://tools.ietf.org/html/rfc7231#section-5.5.3)
+/// [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3)
 ///
 /// The `User-Agent` header field contains information about the user
 /// agent originating the request, which is often used by servers to help

--- a/src/disabled/accept.rs
+++ b/src/disabled/accept.rs
@@ -3,7 +3,7 @@ use mime::{self, Mime};
 use {QualityItem, qitem};
 
 header! {
-    /// `Accept` header, defined in [RFC7231](http://tools.ietf.org/html/rfc7231#section-5.3.2)
+    /// `Accept` header, defined in [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.2)
     ///
     /// The `Accept` header field can be used by user agents to specify
     /// response media types that are acceptable.  Accept header fields can

--- a/src/disabled/accept_charset.rs
+++ b/src/disabled/accept_charset.rs
@@ -2,7 +2,7 @@ use {Charset, QualityItem};
 
 header! {
     /// `Accept-Charset` header, defined in
-    /// [RFC7231](http://tools.ietf.org/html/rfc7231#section-5.3.3)
+    /// [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.3)
     ///
     /// The `Accept-Charset` header field can be sent by a user agent to
     /// indicate what charsets are acceptable in textual response content.

--- a/src/disabled/accept_encoding.rs
+++ b/src/disabled/accept_encoding.rs
@@ -2,7 +2,7 @@ use {Encoding, QualityItem};
 
 header! {
     /// `Accept-Encoding` header, defined in
-    /// [RFC7231](http://tools.ietf.org/html/rfc7231#section-5.3.4)
+    /// [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.4)
     ///
     /// The `Accept-Encoding` header field can be used by user agents to
     /// indicate what response content-codings are

--- a/src/disabled/accept_language.rs
+++ b/src/disabled/accept_language.rs
@@ -3,7 +3,7 @@ use QualityItem;
 
 header! {
     /// `Accept-Language` header, defined in
-    /// [RFC7231](http://tools.ietf.org/html/rfc7231#section-5.3.5)
+    /// [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.5)
     ///
     /// The `Accept-Language` header field can be used by user agents to
     /// indicate the set of natural languages that are preferred in the

--- a/src/disabled/from.rs
+++ b/src/disabled/from.rs
@@ -1,5 +1,5 @@
 header! {
-    /// `From` header, defined in [RFC7231](http://tools.ietf.org/html/rfc7231#section-5.5.1)
+    /// `From` header, defined in [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.1)
     ///
     /// The `From` header field contains an Internet email address for a
     /// human user who controls the requesting user agent.  The address ought

--- a/src/disabled/link.rs
+++ b/src/disabled/link.rs
@@ -11,7 +11,7 @@ use parsing;
 use {Header, Raw};
 
 /// The `Link` header, defined in
-/// [RFC5988](http://tools.ietf.org/html/rfc5988#section-5)
+/// [RFC5988](https://datatracker.ietf.org/doc/html/rfc5988#section-5)
 ///
 /// # ABNF
 ///
@@ -76,7 +76,7 @@ pub struct Link {
 }
 
 /// A single `link-value` of a `Link` header, based on:
-/// [RFC5988](http://tools.ietf.org/html/rfc5988#section-5)
+/// [RFC5988](https://datatracker.ietf.org/doc/html/rfc5988#section-5)
 #[derive(Clone, PartialEq, Debug)]
 pub struct LinkValue {
     /// Target IRI: `link-value`.

--- a/src/disabled/prefer.rs
+++ b/src/disabled/prefer.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use {Header, Raw};
 use parsing::{from_comma_delimited, fmt_comma_delimited};
 
-/// `Prefer` header, defined in [RFC7240](http://tools.ietf.org/html/rfc7240)
+/// `Prefer` header, defined in [RFC7240](https://datatracker.ietf.org/doc/html/rfc7240)
 ///
 /// The `Prefer` header field can be used by a client to request that certain
 /// behaviors be employed by a server while processing a request.

--- a/src/disabled/preference_applied.rs
+++ b/src/disabled/preference_applied.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use {Header, Raw, Preference};
 use parsing::{from_comma_delimited, fmt_comma_delimited};
 
-/// `Preference-Applied` header, defined in [RFC7240](http://tools.ietf.org/html/rfc7240)
+/// `Preference-Applied` header, defined in [RFC7240](https://datatracker.ietf.org/doc/html/rfc7240)
 ///
 /// The `Preference-Applied` response header may be included within a
 /// response message as an indication as to which `Prefer` header tokens were


### PR DESCRIPTION
http://tools.ietf.org/html/ links now redirect to
https://datatracker.ietf.org/doc/html/

this patch applies that change directly in the docs, just in case those redirects ever stop working,
and to save some time on the reader their part