### PR TITLE
Add `ContentEncoding::zstd`

### DIFF
--- a/src/common/content_encoding.rs
+++ b/src/common/content_encoding.rs
@@ -24,6 +24,7 @@ use crate::util::FlatCsv;
 ///
 /// * `gzip`
 /// * `br`
+/// * `zstd`
 ///
 /// # Examples
 ///
@@ -51,6 +52,12 @@ impl ContentEncoding {
     #[inline]
     pub fn brotli() -> ContentEncoding {
         ContentEncoding(HeaderValue::from_static("br").into())
+    }
+
+    /// A constructor to easily create a `Content-Encoding: zstd` header.
+    #[inline]
+    pub fn zstd() -> ContentEncoding {
+        ContentEncoding(HeaderValue::from_static("zstd").into())
     }
 
     /// Check if this header contains a given "coding".


### PR DESCRIPTION
Same as #158 but for zstd, which is currently available in Firefox and Chromium based browsers [^1] and `reqwest` [^2]

[^1]: https://caniuse.com/zstd
[^2]: https://github.com/seanmonstar/reqwest/pull/1866