### PR TITLE
fix(tests): Fix test compile error with nightly feature

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -93,13 +93,13 @@ macro_rules! bench_header {
         #[cfg(feature = "nightly")]
         mod $mod {
             use super::$ty;
-            use HeaderMapExt;
+            use crate::HeaderMapExt;
 
             #[bench]
             fn bench_decode(b: &mut ::test::Bencher) {
                 let mut map = ::http::HeaderMap::new();
                 map.append(
-                    <$ty as ::Header>::name(),
+                    <$ty as crate::Header>::name(),
                     $value.parse().expect("HeaderValue::from_str($value)"),
                 );
                 b.bytes = $value.len() as u64;
@@ -112,7 +112,7 @@ macro_rules! bench_header {
             fn bench_encode(b: &mut ::test::Bencher) {
                 let mut map = ::http::HeaderMap::new();
                 map.append(
-                    <$ty as ::Header>::name(),
+                    <$ty as crate::Header>::name(),
                     $value.parse().expect("HeaderValue::from_str($value)"),
                 );
                 let typed = map.typed_get::<$ty>().unwrap();


### PR DESCRIPTION
Closes #195. On this branch, the command `cargo +nightly bench --features nightly` can now be run without any compiler errors.