### PR TITLE
feat: const `::from_static()` constructors

### DIFF
--- a/src/common/referer.rs
+++ b/src/common/referer.rs
@@ -43,7 +43,7 @@ impl Referer {
     /// # Panic
     ///
     /// Panics if the string is not a legal header value.
-    pub fn from_static(s: &'static str) -> Referer {
+    pub const fn from_static(s: &'static str) -> Referer {
         Referer(HeaderValueString::from_static(s))
     }
 }

--- a/src/common/server.rs
+++ b/src/common/server.rs
@@ -43,7 +43,7 @@ impl Server {
     /// # Panic
     ///
     /// Panics if the static string is not a legal header value.
-    pub fn from_static(s: &'static str) -> Server {
+    pub const fn from_static(s: &'static str) -> Server {
         Server(HeaderValueString::from_static(s))
     }
 

--- a/src/common/user_agent.rs
+++ b/src/common/user_agent.rs
@@ -52,7 +52,7 @@ impl UserAgent {
     /// # Panic
     ///
     /// Panics if the static string is not a legal header value.
-    pub fn from_static(src: &'static str) -> UserAgent {
+    pub const fn from_static(src: &'static str) -> UserAgent {
         UserAgent(HeaderValueString::from_static(src))
     }
 

--- a/src/util/value_string.rs
+++ b/src/util/value_string.rs
@@ -35,7 +35,7 @@ impl HeaderValueString {
             .map(|value| HeaderValueString { value })
     }
 
-    pub(crate) fn from_static(src: &'static str) -> HeaderValueString {
+    pub(crate) const fn from_static(src: &'static str) -> HeaderValueString {
         // A valid `str` (the argument)...
         HeaderValueString {
             value: HeaderValue::from_static(src),


### PR DESCRIPTION
`const`ifies the `headers::{Referer, Server, UserAgent}::from_static()` constructors, since a good deal of the functionality is being able to fail constructing invalid values -- in const contexts -- at compile time