### PR TITLE
feat: Add `impl From<http::HeaderName> for Vary`

### DIFF
--- a/src/common/vary.rs
+++ b/src/common/vary.rs
@@ -1,4 +1,4 @@
-use http::HeaderValue;
+use http::{HeaderName, HeaderValue};
 
 use crate::util::FlatCsv;
 
@@ -50,6 +50,12 @@ impl Vary {
     /// Iterate the header names of this `Vary`.
     pub fn iter_strs(&self) -> impl Iterator<Item = &str> {
         self.0.iter()
+    }
+}
+
+impl From<HeaderName> for Vary {
+    fn from(name: HeaderName) -> Self {
+        Vary(HeaderValue::from(name).into())
     }
 }
 


### PR DESCRIPTION
It seems like a good start since one of `Vary`'s common forms is a list of `HeaderName`s

---

I went with this as the relatively non-controversial impl, but I think it would be nice if there was a `FromIterator<HeaderName> for Vary` impl as well which I'd be happy to add if that sounds good