### PR TITLE
chore: prepare for releasing 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headers"
-version = "0.4.0" # don't forget to update html_root_url
+version = "0.4.1" # don't forget to update html_root_url
 description = "typed HTTP headers"
 license = "MIT"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
-#![doc(html_root_url = "https://docs.rs/headers/0.4.0")]
+#![doc(html_root_url = "https://docs.rs/headers/0.4.1")]
 
 //! # Typed HTTP Headers
 //!


### PR DESCRIPTION
cc @seanmonstar I noticed that we already upgrade base64 to 0.22 but not yet cut a new release.

Is it suitable to cut a 0.4.1 release for updating this (internal) dependency?

This closes https://github.com/hyperium/headers/pull/123.