### PR TITLE
increase MSRV to 1.57 to match `http` crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,24 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: taiki-e/install-action@cargo-hack
-      - run: cargo hack --rust-version --no-dev-deps check --workspace
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Resolve MSRV aware dependencies
+        run: cargo update
+        env:
+          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
+
+      - name: Get MSRV from package metadata
+        id: msrv
+        run: echo "version=$(yq '.package.rust-version' Cargo.toml)" >> $GITHUB_OUTPUT
+
+      - name: Install Rust (${{ steps.msrv.outputs.version }})
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.version }}
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check
+        run: cargo check --workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Sean McArthur <sean@seanmonstar.com>"]
 keywords = ["http", "headers", "hyper", "hyperium"]
 categories = ["web-programming"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [workspace]
 members = ["headers-core"]

--- a/headers-core/Cargo.toml
+++ b/headers-core/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/hyperium/headers"
 authors = ["Sean McArthur <sean@seanmonstar.com>"]
 keywords = ["http", "headers", "hyper", "hyperium"]
 edition = "2018"
-rust-version = "1.49"
+rust-version = "1.57"
 
 [dependencies]
 http = "1.0.0"


### PR DESCRIPTION
coming from the error in #223 (in [CI](https://github.com/hyperium/headers/actions/runs/22338758393/job/64690694412?pr=223))

* [1.57 to match `http` crate](https://docs.rs/crate/http/latest/source/Cargo.toml.orig)