### PR TITLE
chore: improve headers maintenance path

### DIFF
--- a/src/common/expires.rs
+++ b/src/common/expires.rs
@@ -48,3 +48,22 @@ impl From<Expires> for SystemTime {
         date.0.into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::{test_decode, test_encode};
+    use super::Expires;
+
+    #[test]
+    fn roundtrip() {
+        let e: Expires = test_decode(&["Sun, 06 Nov 1994 08:49:37 GMT"]).unwrap();
+        let headers = test_encode(e);
+        let e2: Expires = test_decode(&[headers["expires"].to_str().unwrap()]).unwrap();
+        assert_eq!(e, e2);
+    }
+
+    #[test]
+    fn reject_malformed_date() {
+        assert!(test_decode::<Expires>(&["not-a-date"]).is_none());
+    }
+}

--- a/src/common/retry_after.rs
+++ b/src/common/retry_after.rs
@@ -85,7 +85,7 @@ impl<'a> From<&'a After> for HeaderValue {
 mod tests {
     use std::time::Duration;
 
-    use super::super::test_decode;
+    use super::super::{test_decode, test_encode};
     use super::RetryAfter;
     use crate::util::HttpDate;
 
@@ -110,4 +110,27 @@ mod tests {
     test_retry_after_datetime!(date_decode_rfc1123, "Sun, 06 Nov 1994 08:49:37 GMT");
     test_retry_after_datetime!(date_decode_rfc850, "Sunday, 06-Nov-94 08:49:37 GMT");
     test_retry_after_datetime!(date_decode_asctime, "Sun Nov  6 08:49:37 1994");
+
+    #[test]
+    fn reject_malformed_http_date() {
+        assert!(test_decode::<RetryAfter>(&["not-a-date"]).is_none());
+    }
+
+    #[test]
+    fn reject_negative_delay() {
+        assert!(test_decode::<RetryAfter>(&["-10"]).is_none());
+    }
+
+    #[test]
+    fn reject_non_numeric_delay() {
+        assert!(test_decode::<RetryAfter>(&["abc"]).is_none());
+    }
+
+    #[test]
+    fn date_roundtrip() {
+        let r: RetryAfter = test_decode(&["Sun, 06 Nov 1994 08:49:37 GMT"]).unwrap();
+        let headers = test_encode(r.clone());
+        let r2: RetryAfter = test_decode(&[headers["retry-after"].to_str().unwrap()]).unwrap();
+        assert_eq!(r, r2);
+    }
 }


### PR DESCRIPTION
Summary:
- Add edge-case unit tests for Retry-After header parsing (e.g., reject malformed HTTP-date values, ensure delay-seconds rejects negative/non-numeric input, round-trip of HTTP-date form) and similar parse/encode round-trip tests for Expires. These are small mechanical test additions inside existing small files, exercising already-implemented parsing branches without behavior changes.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.