### PR TITLE
Return an error for degenerate Range/ContentRange bounds instead of overflowing (#231)

### DIFF
--- a/src/common/content_range.rs
+++ b/src/common/content_range.rs
@@ -55,20 +55,28 @@ impl ContentRange {
     ) -> Result<ContentRange, InvalidContentRange> {
         let complete_length = complete_length.into();
 
+        // Use checked arithmetic so degenerate/empty bounds return an error
+        // instead of overflowing (e.g. an exclusive end of 0). (#231)
+        let err = || InvalidContentRange { _inner: () };
+
         let start = match range.start_bound() {
             Bound::Included(&s) => s,
-            Bound::Excluded(&s) => s + 1,
+            Bound::Excluded(&s) => s.checked_add(1).ok_or_else(err)?,
             Bound::Unbounded => 0,
         };
 
         let end = match range.end_bound() {
             Bound::Included(&e) => e,
-            Bound::Excluded(&e) => e - 1,
+            Bound::Excluded(&e) => e.checked_sub(1).ok_or_else(err)?,
             Bound::Unbounded => match complete_length {
-                Some(max) => max - 1,
-                None => return Err(InvalidContentRange { _inner: () }),
+                Some(max) => max.checked_sub(1).ok_or_else(err)?,
+                None => return Err(err()),
             },
         };
+
+        if start > end {
+            return Err(err());
+        }
 
         Ok(ContentRange {
             range: Some((start, end)),
@@ -236,3 +244,20 @@ test_header!(test_bytes_unknown_range,
             vec![b"bytes 1-2-3/500"],
             None::<ContentRange>);
 */
+
+#[cfg(test)]
+mod tests {
+    use super::ContentRange;
+
+    #[test]
+    fn bytes_rejects_degenerate_bounds() {
+        // #231: bounds that would underflow or produce start > end must return
+        // an error instead of overflowing the u64 arithmetic.
+        assert!(ContentRange::bytes(0u64..0u64, 500u64).is_err());
+        assert!(ContentRange::bytes(3u64..3u64, 500u64).is_err());
+        assert!(ContentRange::bytes(.., 0u64).is_err());
+        // Valid ranges still work.
+        assert!(ContentRange::bytes(0u64..500u64, 500u64).is_ok());
+        assert!(ContentRange::bytes(0u64..=499u64, 500u64).is_ok());
+    }
+}

--- a/src/common/range.rs
+++ b/src/common/range.rs
@@ -53,6 +53,11 @@ impl Range {
         let v = match (bounds.start_bound(), bounds.end_bound()) {
             (Bound::Included(start), Bound::Included(end)) => format!("bytes={}-{}", start, end),
             (Bound::Included(start), Bound::Excluded(&end)) => {
+                // An exclusive end of 0 (or <= start) has no last byte, so
+                // `end - 1` would underflow / produce an invalid range. (#231)
+                if end <= *start {
+                    return Err(InvalidRange { _inner: () });
+                }
                 format!("bytes={}-{}", start, end - 1)
             }
             (Bound::Included(start), Bound::Unbounded) => format!("bytes={}-", start),
@@ -455,4 +460,16 @@ fn test_to_unsatisfiable_range_suffix() {
     let range = super::test_decode::<Range>(&["bytes=-350"]).unwrap();
     let bounds = range.satisfiable_ranges(100).next();
     assert_eq!(bounds, None);
+}
+
+#[test]
+fn test_bytes_rejects_degenerate_bounds() {
+    // #231: an exclusive end that would underflow (`0`) or produce an invalid
+    // start > last range must error rather than panic or emit a bogus range.
+    assert!(Range::bytes(0u64..0u64).is_err());
+    assert!(Range::bytes(3u64..3u64).is_err());
+    assert!(Range::bytes(5u64..3u64).is_err());
+    // Valid ranges still work.
+    assert!(Range::bytes(0u64..500u64).is_ok());
+    assert!(Range::bytes(0u64..=500u64).is_ok());
 }


### PR DESCRIPTION
Fixes #231.

### Problem

`Range::bytes` and `ContentRange::bytes` do unchecked `u64` arithmetic on the bounds:

- `Range::bytes(0u64..0u64)` computes `end - 1` on the exclusive end → panics in debug (`attempt to subtract with overflow`), and in release emits `bytes=0-18446744073709551615` (a 2^64-byte span). `Range::bytes(3u64..3u64)` yields `bytes=3-2` (start > last).
- `ContentRange::bytes` has the same class of bug: Excluded-start `s + 1` overflows at `u64::MAX`, Excluded-end `e - 1` underflows at `0`, and an Unbounded end with `complete_length: Some(0)` underflows on `max - 1`.

### Fix

Both constructors already return a `Result` and already `Err` on other invalid inputs (e.g. unbounded-start arms), so the contract-consistent fix is to return that same error for degenerate/empty/overflowing bounds using checked arithmetic, rather than panicking or emitting an invalid header.

### Test

Added `test_bytes_rejects_degenerate_bounds` (range.rs) and `bytes_rejects_degenerate_bounds` (content_range.rs). Red-green verified with `cargo test`: before the change both panic with `attempt to subtract with overflow`; after, the degenerate cases return `Err` and valid ranges still succeed. `cargo fmt --check` is clean and the change adds no new clippy warnings.

---
Disclosure: I used AI assistance (Claude) while preparing this change. I reproduced the overflow, ran the tests (red-green), and take responsibility for the contribution.
