### PR TITLE
fix: Access-Control-Request-Headers must join header names without whitespace

### DIFF
--- a/src/common/access_control_request_headers.rs
+++ b/src/common/access_control_request_headers.rs
@@ -53,8 +53,23 @@ impl FromIterator<HeaderName> for AccessControlRequestHeaders {
     where
         I: IntoIterator<Item = HeaderName>,
     {
-        let flat = iter.into_iter().map(HeaderValue::from).collect();
-        AccessControlRequestHeaders(flat)
+        // Per the Fetch spec's CORS-preflight fetch, the value of
+        // `Access-Control-Request-Headers` joins header names with a plain
+        // `,` and no whitespace. This differs from the general list `combine`
+        // (`, `) that `FlatCsv`'s `FromIterator` performs, so join the names
+        // here directly rather than delegating to `FlatCsv`. Keeping this
+        // local leaves other `FlatCsv`-backed headers (Vary, Allow, ...)
+        // emitting `, ` as before.
+        let mut names = String::new();
+        for name in iter {
+            if !names.is_empty() {
+                names.push(',');
+            }
+            names.push_str(name.as_str());
+        }
+        let value = HeaderValue::from_bytes(names.as_bytes())
+            .expect("header names joined by `,` are a valid header value");
+        AccessControlRequestHeaders(value.into())
     }
 }
 
@@ -83,7 +98,23 @@ mod tests {
         let headers = test_encode(req_headers);
         assert_eq!(
             headers["access-control-request-headers"],
-            "cache-control, if-range"
+            "cache-control,if-range"
+        );
+    }
+
+    #[test]
+    fn from_iter_no_space_between_names() {
+        // Per the Fetch spec the preflight `Access-Control-Request-Headers`
+        // value must join header names with `,` only, no whitespace.
+        let req_headers: AccessControlRequestHeaders =
+            vec![::http::header::ACCEPT_LANGUAGE, ::http::header::DATE]
+                .into_iter()
+                .collect();
+
+        let headers = test_encode(req_headers);
+        assert_eq!(
+            headers["access-control-request-headers"],
+            "accept-language,date"
         );
     }
 }


### PR DESCRIPTION
Fixes #207

## Problem
`AccessControlRequestHeaders::from_iter` collects `HeaderName`s into the shared `FlatCsv`, whose `FromIterator` joins with `, ` (comma + space). But the [Fetch CORS-preflight fetch spec](https://fetch.spec.whatwg.org/#cors-preflight-fetch) specifies the `Access-Control-Request-Headers` value is a `,`-joined list with **no whitespace** (it does not use `combine`). The WPT test `access-control-preflight-request-header-sorted.py` checks this strictly, and MDN's example value has no spaces. So the typed API currently emits `accept-language, date` instead of `accept-language,date`.

@seanmonstar acknowledged this in #207 ("Well that's unfortunate (as the spec even says).") but no fix was posted.

## Fix
Give `AccessControlRequestHeaders` its own `FromIterator<HeaderName>` that joins the names with a plain `,` and wraps the result in a `HeaderValue`, instead of delegating to `FlatCsv`'s `, ` joiner. The change is localized: shared `FlatCsv` is left untouched, so other list headers (Vary, Allow, ...) keep emitting `, `.

The one existing `from_iter` test expectation is updated from `"cache-control, if-range"` to `"cache-control,if-range"`, and a new test `from_iter_no_space_between_names` asserts the joined value is `accept-language,date` (no space).

## Verification
- Red/green: with the old delegation the new test fails (`accept-language, date`); with the fix it passes.
- `cargo test --lib`: all pass, no regression.
- `cargo fmt --check` clean; `cargo clippy` introduces no new warnings.

---
This contribution was made with AI assistance.